### PR TITLE
showNextRun() method will show next scheduled time for job

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -103,6 +103,11 @@ function Job(){
 		
 		return true;
 	};
+	this.showNextRun = function(){
+		if(pendingInvocations[0]){
+			return pendingInvocations[0].fireDate;
+		}
+	};
 }
 
 util.inherits(Job, events.EventEmitter);


### PR DESCRIPTION
I needed a way to view the next time a scheduled job will run.  I've added a simple showNextRun() method to the Job that will output the date and time it will be run next.
