### PR TITLE
Exposing function to retrieve the next invocation of a job

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -103,6 +103,11 @@ function Job(){
 		
 		return true;
 	};
+	this.nextInvocation = function(){
+		if (pendingInvocations.length == 0)
+			return null;
+		return pendingInvocations[0].fireDate;
+	};
 }
 
 util.inherits(Job, events.EventEmitter);


### PR DESCRIPTION
I had an example where I had 2 jobs scheduled (one to start and the other to stop a service). I needed to determine which job was going to fire first, so I needed to get the next run date of each job to compare them. This seemed to be the neatest solution I could think of.
