### PR TITLE
fix to addDay - use setDate instead of setTime, crossing DST problem.

### DIFF
--- a/lib/increment.js
+++ b/lib/increment.js
@@ -71,7 +71,7 @@ Date.prototype.addDay = function(){
 		this.addMonth();
 	}
 	else
-        this.setTime(this.getTime() + (24 * 60 * 60 * 1000));
+        this.setDate(d);
 };
 
 Date.prototype.addHour = function(){


### PR DESCRIPTION
Using setTime in addDay() and crossing over DST change date gives:
before setTime: Sun Oct 27 2013 00:00:00 GMT+0300 (Jerusalem Daylight Time)
after setTime: Sun Oct 27 2013 23:00:00 GMT+0200 (Jerusalem Standard Time)

Actually staying on same day and going to infinite loop.
