### PR TITLE
Date.prototype.addXXX change & fix, execute job even if passed the date

### DIFF
--- a/lib/increment.js
+++ b/lib/increment.js
@@ -6,103 +6,26 @@
 	in the Gregorian calendar.
 */
 
-var monthCount = 12;
-
-var normalDaySpec = [
-	31,	// January
-	28,	// February
-	31,	// March
-	30,	// April
-	31,	// May
-	30, // June
-	31,	// July
-	31,	// August
-	30,	// September
-	31,	// October
-	30,	// November
-	31	// December
-];
-var leapDaySpec = [
-	31,	// January
-	29,	// February
-	31,	// March
-	30,	// April
-	31,	// May
-	30, // June
-	31,	// July
-	31,	// August
-	30,	// September
-	31,	// October
-	30,	// November
-	31	// December
-];
-
-// provide a year-specific day spec
-function daySpec(year){
-	return ((year % 400 == 0 || (year % 4 == 0 && year % 100 != 0)) ? leapDaySpec : normalDaySpec);
-}
-
 Date.prototype.addYear = function(){
 	this.setFullYear(this.getFullYear() + 1);
 };
 
 Date.prototype.addMonth = function(){
-	var m = this.getMonth() + 1;
-	if (m == monthCount)
-	{
-        this.setMonth(0);
-		this.addYear();
-	}
-	else
-    {
-        var spec = daySpec(this.getFullYear());
-        if (this.getDate() > spec[m])
-            this.setDate(spec[m]);
-    	this.setMonth(m);
-    }
+	this.setMonth(this.getMonth() + 1);
 };
 
 Date.prototype.addDay = function(){
-	var spec = daySpec(this.getFullYear());
-	var d = this.getDate() + 1;
-	if (d > spec[this.getMonth()])
-	{
-		this.setDate(1)
-		this.addMonth();
-	}
-	else
-        this.setDate(d);
+	this.setDate(this.getDate() + 1);
 };
 
 Date.prototype.addHour = function(){
-	var h = this.getHours() + 1;
-	if (h == 24)
-	{
-        this.setHours(0);
-		this.addDay();
-	}
-	else
-    	this.setTime(this.getTime() + (60 * 60 * 1000));
+	this.setTime(this.getTime() + (60 * 60 * 1000));
 };
 
 Date.prototype.addMinute = function(){
-	var m = this.getMinutes() + 1;
-	if (m == 60)
-	{
-		this.setMinutes(0);
-		this.addHour();
-	}
-	else
-        this.setTime(this.getTime() + (60 * 1000));
+	this.setTime(this.getTime() + (60 * 1000));
 };
 
 Date.prototype.addSecond = function(){
-	var s = this.getSeconds() + 1;
-	if (s == 60)
-	{
-		this.setSeconds(0);
-		this.addMinute();
-	}
-	else
-        this.setTime(this.getTime() + 1000);
+	this.setTime(this.getTime() + 1000);
 };

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -486,7 +486,7 @@ function runOnDate(date, job){
 	
 	if (then < now)
     {
-        if (now - then < 1000)
+//        if (now - then < 1000)
             process.nextTick(job);
         return null;
     }


### PR DESCRIPTION
The issue is with the "Date.prototype.addXXXX" functions.
It seems that there is too much logic there that makes things not work very well when crossing DST.

From my expression it seems that increments related to time should be treated only with "Date.setTime", as time is stored in UTC epoch time.

```
    date.setTime(date.getTime() + 1000) // 1 second
    date.setTime(date.getTime() + 60*1000) // 1 minute
    date.setTime(date.getTime() + 60*60*1000) // 1 hour
```

Use only these codes without the check of full interval (f.e. if (s == 60) {} )

While increments related to date (day, month, year) which is based not only on the UTC time, but also on the attached timezone and timezone's rules for DST, it isn't correct to use function like "setTime" which treats only the UTC time.

```
    date.setDate(date.getDate() + 1) // 1 day
    date.setMonth(date.getMonth() + 1) // 1 month
    date.setFullYear(date.getFullYear() + 1) // 1 year
```

Here also use only this simple commands, no extra checking for date == 31, month == 12, as JS does it automatically considering all the parameters.
