### PR TITLE
Removed Date.prototype methods as it is not a good idea to extend global objects, Added the ability to pass in date strings as valid schedule times

### DIFF
--- a/lib/increment.js
+++ b/lib/increment.js
@@ -6,26 +6,33 @@
 	in the Gregorian calendar.
 */
 
-Date.prototype.addYear = function(){
-	this.setFullYear(this.getFullYear() + 1);
-};
+exports = module.exports.addDateConvenienceMethods = addDateConvenienceMethods;
 
-Date.prototype.addMonth = function(){
-	this.setMonth(this.getMonth() + 1);
-};
+function addDateConvenienceMethods(Date){
+    if(typeof Date.addYear !== 'function'){
+        Date.addYear = function(){
+            this.setFullYear(this.getFullYear() + 1);
+        };
 
-Date.prototype.addDay = function(){
-	this.setDate(this.getDate() + 1);
-};
+        Date.addMonth = function(){
+            this.setMonth(this.getMonth() + 1);
+        };
 
-Date.prototype.addHour = function(){
-	this.setTime(this.getTime() + (60 * 60 * 1000));
-};
+        Date.addDay = function(){
+            this.setDate(this.getDate() + 1);
+        };
 
-Date.prototype.addMinute = function(){
-	this.setTime(this.getTime() + (60 * 1000));
-};
+        Date.addHour = function(){
+            this.setTime(this.getTime() + (60 * 60 * 1000));
+        };
 
-Date.prototype.addSecond = function(){
-	this.setTime(this.getTime() + 1000);
-};
+        Date.addMinute = function(){
+            this.setTime(this.getTime() + (60 * 1000));
+        };
+
+        Date.addSecond = function(){
+            this.setTime(this.getTime() + 1000);
+        };
+    }
+}
+

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -123,8 +123,8 @@ Job.prototype.runOnDate = function(date){
 
 Job.prototype.schedule = function(spec){
 	var success = false;
-	var job = this;
-	
+
+  spec = dateSpec(spec);	
 	if (typeof(spec) == 'object' && spec instanceof Date)
 	{
 		var inv = new Invocation(this, spec);
@@ -170,6 +170,15 @@ Job.prototype.schedule = function(spec){
 	return success;
 };
 
+function dateSpec(spec) {
+    if (spec instanceof Date === false) {
+        var validDate = new Date(spec);
+        if (validDate.toString() !== 'Invalid Date') {
+            spec = validDate;
+        }
+    }
+    return spec;
+}
 
 /* API
 	invoke()
@@ -381,15 +390,17 @@ RecurrenceRule.prototype.validate = function(){
 
 RecurrenceRule.prototype.nextInvocationDate = function(base){
 	base = (base instanceof Date) ? base : (new Date());
-	
+  increment.addDateConvenienceMethods(base);
 	if (!this.recurs)
 		return null;
 	
 	var now = new Date();
+  increment.addDateConvenienceMethods(now);
 	if (this.year !== null && (typeof(this.year) == 'number') && this.year < now.getFullYear())
 		return null;
 	
 	var next = new Date(base.getTime());
+  increment.addDateConvenienceMethods(next);
 	next.addSecond();
 	
 	while (true)
@@ -633,3 +644,5 @@ exports.Invocation = Invocation;
 exports.scheduleJob = scheduleJob;
 exports.scheduledJobs = scheduledJobs;
 exports.cancelJob = cancelJob;
+exports.addDateConvenienceMethods = increment.addDateConvenienceMethods;
+

--- a/test/date-convenience-methods-test.js
+++ b/test/date-convenience-methods-test.js
@@ -1,0 +1,40 @@
+var main = require('../package.json').main;
+var schedule = require('../' + main);
+
+module.exports = {
+    "Date Enhancements":{
+        "Should Not add date convenience methods unless explicitly specified": function(test){
+            test.ok(typeof Date.addYear !== 'function');
+            test.ok(typeof Date.addMonth !== 'function');
+            test.ok(typeof Date.addDay !== 'function');
+            test.ok(typeof Date.addHour !== 'function');
+            test.ok(typeof Date.addMinute !== 'function');
+            test.ok(typeof Date.addSecond !== 'function');
+            test.done();
+        },
+        "Should add date convenience methods when explicitly specified": function(test){
+            schedule.addDateConvenienceMethods(Date);
+            test.ok(typeof Date.addYear === 'function');
+            test.ok(typeof Date.addMonth === 'function');
+            test.ok(typeof Date.addDay === 'function');
+            test.ok(typeof Date.addHour === 'function');
+            test.ok(typeof Date.addMinute === 'function');
+            test.ok(typeof Date.addSecond === 'function');
+            test.done();
+        }
+    },
+    "Date string":{
+        "Should accept a valid date string": function(test){
+            test.expect(1);
+
+            schedule.scheduleJob(new Date(Date.now() + 1000).toString(), function() {
+                test.ok(true);
+            });
+
+            setTimeout(function() {
+                test.done();
+            }, 1250);
+        }
+    }
+};
+


### PR DESCRIPTION
Ok took a while to get my formatting the same as yours but should be good now.
