### PR TITLE
Hack to detect cron specs

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -171,6 +171,9 @@ Job.prototype.schedule = function(spec){
 };
 
 function dateSpec(spec) {
+    //HACK to detect cron-style specs.  They always have 5 items ("* * * * *")
+    if(spec.split(" ").length ===5){return spec;}
+
     if (spec instanceof Date === false) {
         var validDate = new Date(spec);
         if (validDate.toString() !== 'Invalid Date') {


### PR DESCRIPTION
new Date(string) is too forgiving and will return a valid date when given a cron-style specification.  This will prevent them from being improperly parsed into the schedule.
