### PR TITLE
Do not convert cron strings to dates

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -124,7 +124,7 @@ Job.prototype.runOnDate = function(date){
 Job.prototype.schedule = function(spec){
 	var success = false;
 
-  spec = dateSpec(spec);	
+        spec = dateSpec(spec);	
 	if (typeof(spec) == 'object' && spec instanceof Date)
 	{
 		var inv = new Invocation(this, spec);
@@ -172,7 +172,7 @@ Job.prototype.schedule = function(spec){
 
 function dateSpec(spec) {
     //HACK to detect cron-style specs.  They always have 5 items ("* * * * *")
-    if(spec.split(" ").length ===5){return spec;}
+    if(typeof(spec)==="string" && spec.split(" ").length ===5){return spec;}
 
     if (spec instanceof Date === false) {
         var validDate = new Date(spec);


### PR DESCRIPTION
new Date() is too forgiving and will accept many cron strings (including those listed in the readme).  This will try to prevent that by detecting incoming strings with 5 items split by spaces, which should catch any cron specifications.
