### PR TITLE
Type verification on recursive function

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -469,7 +469,7 @@ function recurMatch(val, matcher){
 	if (matcher == null)
 		return true;
 	
-	if (typeof(matcher) == 'number')
+	if (typeof(matcher) == 'number' || typeof(matcher) == 'string')
 		return (val == matcher);
 	else if (typeof(matcher) == 'object' && matcher instanceof Range)
 		return matcher.contains(val);


### PR DESCRIPTION
It happens if some properties are passed as string and not numbers:

scheduler.schedule(id, {
        dayOfWeek : [0],
        hour      : "12",
        minute    : "00"
    }, function(){
        console.log("**********************\* " + id + "********************");
    }
);

The program hangs in a infinite loop.
