### PR TITLE
Fix issue where it thinks the cron string is a valid js date and ...

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -171,7 +171,7 @@ Job.prototype.schedule = function(spec){
 };
 
 function dateSpec(spec) {
-    if (spec instanceof Date === false) {
+    if (spec instanceof Date === true) {
         var validDate = new Date(spec);
         if (validDate.toString() !== 'Invalid Date') {
             spec = validDate;


### PR DESCRIPTION
tries to convert the cron string to a  date.

Very small change, but fixes the bug with job kicking off when the scheduler starts.
