### PR TITLE
fix forever loop and date validation

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -173,7 +173,7 @@ Job.prototype.schedule = function(spec){
 function dateSpec(spec) {
     if (spec instanceof Date === false) {
         var validDate = new Date(spec);
-        if (validDate.toString() !== 'Invalid Date') {
+        if (validDate.toString() !== 'Invalid Date' && validDate >= new Date()) { // TODO : submit a fix for new Date("0 * * * *")
             spec = validDate;
         }
     }
@@ -405,6 +405,10 @@ RecurrenceRule.prototype.nextInvocationDate = function(base){
 	
 	while (true)
 	{
+		if (isNaN(next.getYear())) { // TODO : submit a fix to support invalid cron schedules ("2 00,14 00 * * 0-7").
+			return null;
+		}
+        
 		if (this.year != null && !recurMatch(next.getYear(), this.year))
 		{
 			next.addYear();


### PR DESCRIPTION
fixed entering invalid cron syntax (2 00,14 00 \* \* 0-7) could generate a forever loop.
tentative fix for date validation which was accepting cron syntax as a valid date.
