### PR TITLE
Allow job objects to be scheduled

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -114,10 +114,11 @@ function Job(){
 util.inherits(Job, events.EventEmitter);
 
 Job.prototype.invoke = function(){
-	if (typeof(this.job) == 'function')
+	if (typeof(this.job) == 'function') {
 		this.job();
-	else
+  } else {
 		this.job.execute();
+  }
 };
 
 Job.prototype.runOnDate = function(date){
@@ -594,8 +595,6 @@ function scheduleJob(){
 	var name = (arguments.length >= 3) ? arguments[0] : null;
 	var spec = (arguments.length >= 3) ? arguments[1] : arguments[0];
 	var method = (arguments.length >= 3) ? arguments[2] : arguments[1];
-	if (typeof(method) != 'function')
-		return null;
 	
 	var job = new Job(name, method);
 	if (job.schedule(spec))


### PR DESCRIPTION
Right now only functions are allowed. I liked the idea of having a job object with a known interface more.
So now i can schedule objects which implement the method 'execute' and node-schedule executes it.
I hope you find the idea interesting. 
~fw
