### PR TITLE
test: make cron tests more resilient

### DIFF
--- a/test/schedule-cron-jobs.js
+++ b/test/schedule-cron-jobs.js
@@ -93,9 +93,9 @@ module.exports = {
       clock.tick(timeout);
     },
     "Runs job every month": function(test) {
-      test.expect(3);
+      test.expect(48);
 
-      var timeout = 3 * 29.53 * 24 * 60 * 60 * 1000;
+      var timeout = 4 * 365.25 * 24 * 60 * 60 * 1000;
 
       var job = schedule.scheduleJob('0 0 0 1 * *', function() {
         test.ok(true);
@@ -107,11 +107,12 @@ module.exports = {
       }, timeout);
 
       clock.tick(timeout);
+
     },
     "Runs job every year": function(test) {
-      test.expect(3);
+      test.expect(4);
 
-      var timeout = 3 * 365.25 * 24 * 60 * 60 * 1000;
+      var timeout = 4 * 365.25 * 24 * 60 * 60 * 1000;
 
       var job = schedule.scheduleJob('0 0 0 1 1 *', function() {
         test.ok(true);


### PR DESCRIPTION
- Up to this change, the tests: 'Runs job every month' and 'Runs job every year'
  would fail or succeed depending on the date they were run. For example:
  running the 'every month' test on "2015-06-01" would fail because the job
  would only run twice and not thrice. The reason being that July and August are
  both 31 days.
- This commit solves these issues by running these tests in a 4 year period to
  be sure the leap year is always taken into account.