### PR TITLE
adds eslint for linting code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,17 @@
+{
+  "env": {
+    "node": true
+  },
+  "rules": {
+    "eqeqeq": [2, "smart"],
+    "curly": [2, "multi-line"],
+    "no-constant-condition": 1,
+    "no-redeclare": 1,
+    "no-shadow": 1,
+    "no-underscore-dangle": false,
+    "no-use-before-define": [true,"nofunc"],
+    "quotes": [2, "single"],
+    "space-before-blocks": 2,
+    "strict": 2
+  }
+}

--- a/lib/increment.js
+++ b/lib/increment.js
@@ -3,7 +3,7 @@
 /*
   node-schedule
   A cron-like and not-cron-like job scheduler for Node.
-  
+
   This file adds convenience functions for performing incremental date math
   in the Gregorian calendar.
 */

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -8,7 +8,7 @@
 var events = require('events'),
   util = require('util'),
   increment = require('./increment.js'),
-  cron_parser = require('cron-parser'),
+  cronParser = require('cron-parser'),
   lt = require('long-timeout');
 
 /* Job object */
@@ -21,7 +21,7 @@ function Job() {
   var arg;
   for (var i = 0; i < arguments.length; i++) {
     arg = arguments[i];
-    if (typeof(arg) == 'string' || arg instanceof String) {
+    if (typeof arg == 'string' || arg instanceof String) {
       name = arg;
     } else {
       this.job = arg;
@@ -61,7 +61,7 @@ function Job() {
     return false;
   };
   this.cancel = function(reschedule) {
-    reschedule = (typeof(reschedule) == 'boolean') ? reschedule : false;
+    reschedule = (typeof reschedule == 'boolean') ? reschedule : false;
 
     var inv, newInv;
     var newInvs = [];
@@ -85,9 +85,9 @@ function Job() {
     return true;
   };
   this.cancelNext = function(reschedule) {
-    reschedule = (typeof(reschedule) == 'boolean') ? reschedule : true;
+    reschedule = (typeof reschedule == 'boolean') ? reschedule : true;
 
-    if (pendingInvocations.length == 0) return false;
+    if (!pendingInvocations.length) return false;
 
     var newInv;
     var nextInv = pendingInvocations.shift();
@@ -102,7 +102,7 @@ function Job() {
     return true;
   };
   this.nextInvocation = function() {
-    if (pendingInvocations.length == 0) return null;
+    if (!pendingInvocations.length) return null;
     return pendingInvocations[0].fireDate;
   };
   this.pendingInvocations = function() {
@@ -113,7 +113,7 @@ function Job() {
 util.inherits(Job, events.EventEmitter);
 
 Job.prototype.invoke = function() {
-  if (typeof(this.job) == 'function') {
+  if (typeof this.job == 'function') {
     this.job();
   } else {
     this.job.execute();
@@ -128,11 +128,11 @@ Job.prototype.schedule = function(spec) {
   var self = this;
   var success = false;
   try {
-    var res = cron_parser.parseExpression(spec);
+    var res = cronParser.parseExpression(spec);
     var inv = scheduleNextRecurrence(res, self);
     if (inv !== null) success = self.trackInvocation(inv);
   } catch (err) {
-    var type = typeof(spec);
+    var type = typeof spec;
     if (type === 'string') spec = new Date(spec);
 
     if (spec instanceof Date) {
@@ -198,7 +198,7 @@ Range.prototype.contains = function(val) {
     return (val >= this.start && val <= this.end);
   } else {
     for (var i = this.start; i < this.end; i += this.step) {
-      if (i == val) return true;
+      if (i === val) return true;
     }
 
     return false;
@@ -239,7 +239,7 @@ RecurrenceRule.prototype.nextInvocationDate = function(base) {
 
   var now = new Date();
   increment.addDateConvenienceMethods(now);
-  if (this.year !== null && (typeof(this.year) == 'number') && this.year < now.getFullYear()) return null;
+  if (this.year !== null && (typeof this.year == 'number') && this.year < now.getFullYear()) return null;
 
   var next = new Date(base.getTime());
   increment.addDateConvenienceMethods(next);
@@ -302,11 +302,11 @@ RecurrenceRule.prototype.nextInvocationDate = function(base) {
 function recurMatch(val, matcher) {
   if (matcher == null) return true;
 
-  if (typeof(matcher) == 'number' || typeof(matcher) == 'string') {
-    return (val == matcher);
-  } else if (typeof(matcher) == 'object' && matcher instanceof Range) {
+  if (typeof matcher === 'number' || typeof matcher === 'string') {
+    return (val === matcher);
+  } else if (typeof matcher === 'object' && matcher instanceof Range) {
     return matcher.contains(val);
-  } else if (Array.isArray(matcher) || (typeof(matcher) == 'object' && matcher instanceof Array)) {
+  } else if (Array.isArray(matcher) || (typeof matcher === 'object' && matcher instanceof Array)) {
     for (var i = 0; i < matcher.length; i++) {
       if (recurMatch(val, matcher[i])) return true;
     }
@@ -344,7 +344,7 @@ function scheduleInvocation(invocation) {
 }
 
 function prepareNextInvocation() {
-  if (invocations.length > 0 && currentInvocation != invocations[0]) {
+  if (invocations.length > 0 && currentInvocation !== invocations[0]) {
     if (currentInvocation !== null) {
       lt.clearTimeout(currentInvocation.timerID);
       currentInvocation.timerID = null;
@@ -383,7 +383,7 @@ function cancelInvocation(invocation) {
     invocations.splice(idx, 1);
     if (invocation.timerID !== null) lt.clearTimeout(invocation.timerID);
 
-    if (currentInvocation == invocation) currentInvocation = null;
+    if (currentInvocation === invocation) currentInvocation = null;
 
     invocation.job.emit('canceled', invocation.fireDate);
     prepareNextInvocation();
@@ -430,14 +430,14 @@ function cancelJob(job) {
     if (success) {
       for (var name in scheduledJobs) {
         if (scheduledJobs.hasOwnProperty(name)) {
-          if (scheduledJobs[name] == job) {
+          if (scheduledJobs[name] === job) {
             scheduledJobs[name] = null;
             break;
           }
         }
       }
     }
-  } else if (typeof(job) == 'string' || job instanceof String) {
+  } else if (typeof job == 'string' || job instanceof String) {
     if (job in scheduledJobs && scheduledJobs.hasOwnProperty(job)) {
       success = scheduledJobs[job].cancel();
       if (success) scheduledJobs[job] = null;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "main": "./lib/schedule.js",
   "scripts": {
-    "test": "./node_modules/.bin/nodeunit test"
+    "test": "./node_modules/.bin/nodeunit test",
+    "lint": "./node_modules/.bin/eslint lib"
   },
   "repository": {
     "type": "git",
@@ -18,6 +19,7 @@
   },
   "dependencies": {
     "cron-parser": "~0.6.1",
+    "eslint": "^0.15.1",
     "long-timeout": "~0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Run via ```npm run lint```. I relaxed the default rules a little bit and changed some things to warn only so I didn't have to change too much code to pass the linter. Let me know what you think.

https://github.com/node-schedule/node-schedule/issues/99