### PR TITLE
refactor code to eliminate lint warnings and to better follow best practices

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
   "rules": {
     "eqeqeq": [2, "smart"],
     "curly": [2, "multi-line"],
-    "no-constant-condition": 1,
+    "no-constant-condition": false,
     "no-redeclare": 1,
     "no-shadow": 1,
     "no-underscore-dangle": false,

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -65,8 +65,8 @@ function Job() {
 
     var inv, newInv;
     var newInvs = [];
-    for (var i = 0; i < pendingInvocations.length; i++) {
-      inv = pendingInvocations[i];
+    for (var j = 0; j < pendingInvocations.length; j++) {
+      inv = pendingInvocations[j];
 
       cancelInvocation(inv);
 
@@ -78,8 +78,8 @@ function Job() {
 
     pendingInvocations = [];
 
-    for (var i = 0; i < newInvs.length; i++) {
-      this.trackInvocation(newInvs[i]);
+    for (var k = 0; k < newInvs.length; k++) {
+      this.trackInvocation(newInvs[k]);
     }
 
     return true;
@@ -127,16 +127,17 @@ Job.prototype.runOnDate = function(date) {
 Job.prototype.schedule = function(spec) {
   var self = this;
   var success = false;
+  var inv;
   try {
     var res = cronParser.parseExpression(spec);
-    var inv = scheduleNextRecurrence(res, self);
+    inv = scheduleNextRecurrence(res, self);
     if (inv !== null) success = self.trackInvocation(inv);
   } catch (err) {
     var type = typeof spec;
     if (type === 'string') spec = new Date(spec);
 
     if (spec instanceof Date) {
-      var inv = new Invocation(self, spec);
+      inv = new Invocation(self, spec);
       scheduleInvocation(inv);
       success = self.trackInvocation(inv);
     } else if (type === 'object') {
@@ -153,7 +154,7 @@ Job.prototype.schedule = function(spec) {
         spec = r;
       }
 
-      var inv = scheduleNextRecurrence(spec, self);
+      inv = scheduleNextRecurrence(spec, self);
       if (inv !== null) success = self.trackInvocation(inv);
     }
   }
@@ -172,6 +173,10 @@ Job.prototype.schedule = function(spec) {
   name: readonly
   job: readwrite
 */
+
+/* DoesntRecur rule */
+var DoesntRecur = new RecurrenceRule();
+DoesntRecur.recurs = false;
 
 /* Invocation object */
 function Invocation(job, fireDate, recurrenceRule) {
@@ -315,10 +320,6 @@ function recurMatch(val, matcher) {
 
   return false;
 }
-
-/* DoesntRecur rule */
-var DoesntRecur = new RecurrenceRule();
-DoesntRecur.recurs = false;
 
 /* Date-based scheduler */
 function runOnDate(date, job) {


### PR DESCRIPTION
Refactors code to eliminate all lint warnings. Also changed a lint rule so ```while(true)``` doesn't throw a warning. 