### PR TITLE
update travis config to lint code before running tests and fix link to t...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
   - "0.12"
   - "0.10"
   - "iojs"
+before_script: npm run lint

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# node-schedule [![Build Status](https://travis-ci.org/node-schedule/node-schedule.svg?branch=master)](https://travis-ci.org/node-schedule/node-schedule.svg)
+# node-schedule [![Build Status](https://travis-ci.org/node-schedule/node-schedule.svg?branch=master)](https://travis-ci.org/node-schedule/node-schedule)
 
 [![NPM](https://nodei.co/npm/node-schedule.png?downloads=true)](https://nodei.co/npm/node-schedule/)
 


### PR DESCRIPTION
...ravis on README

Travis now lints code before running tests, if linting fails then travis will fail the build. Tested on travis with my fork. See https://travis-ci.org/jonhester/node-schedule/jobs/53125042 for an example of a failed lint. Also fixes the travis image on the readme to link to the travis project instead of the image.