### PR TITLE
increase test coverage for recurrence rule and job

### DIFF
--- a/test/job-test.js
+++ b/test/job-test.js
@@ -46,6 +46,37 @@ module.exports = {
 
       clock.tick(3250);
     },
+    "Cancel next job before it runs": function(test) {
+      test.expect(1);
+
+      var job = new schedule.Job(function() {
+        test.ok(true);
+      });
+
+      job.schedule(new Date(Date.now() + 1500));
+      job.schedule(new Date(Date.now() + 3000));
+      job.cancelNext();
+      setTimeout(function() {
+        test.done();
+      }, 3250);
+
+      clock.tick(3250);
+    },
+    "Run job on specified date": function(test) {
+      test.expect(1);
+
+      var job = new schedule.Job(function() {
+        test.ok(true);
+      });
+
+      job.runOnDate(new Date(Date.now() + 3000));
+     
+      setTimeout(function() {
+        test.done();
+      }, 3250);
+
+      clock.tick(3250);
+    },
     /* No jobs will run after this test for some reason - hide for now
     "Won't run job if scheduled in the past": function(test) {
       test.expect(0);

--- a/test/recurrence-rule-test.js
+++ b/test/recurrence-rule-test.js
@@ -123,7 +123,6 @@ module.exports = {
       test.deepEqual(new Date(2011, 1, 1, 0, 0, 0, 0), next);
       test.done();
     },
-    /*
     "in the year 2040": function(test) {
       var rule = new schedule.RecurrenceRule();
       rule.year = 2040;
@@ -133,7 +132,15 @@ module.exports = {
       test.deepEqual(new Date(2040, 0, 1, 0, 0, 0, 0), next);
       test.done();
     },
-    */
+    "using past year": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.year = 2000;
+
+      var next = rule.nextInvocationDate(base);
+
+      test.equal(null, next);
+      test.done();
+    },
     "using mixed time components": function(test) {
       var rule = new schedule.RecurrenceRule();
       rule.second = 50;


### PR DESCRIPTION
I noticed that the tests weren't even running the https://github.com/node-schedule/node-schedule/blob/master/lib/schedule.js#L255-261. I also added a test for scheduling a past job, and canceling the next job.