### PR TITLE
API method 'getJob', index jobs (needs tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# node-schedule [![NPM version](http://img.shields.io/npm/v/node-schedule.svg)](https://www.npmjs.com/package/node-schedule) [![Downloads](https://img.shields.io/npm/dm/node-schedule.svg)](https://www.npmjs.com/package/node-schedule) [![Build Status](https://travis-ci.org/node-schedule/node-schedule.svg?branch=master)](https://travis-ci.org/node-schedule/node-schedule)
+# node-schedule [![NPM version](http://img.shields.io/npm/v/node-schedule.svg)](https://www.npmjs.com/package/node-schedule) [![Downloads](https://img.shields.io/npm/dm/node-schedule.svg)](https://www.npmjs.com/package/node-schedule) [![Coverage Status](https://coveralls.io/repos/node-schedule/node-schedule/badge.svg?branch=master)](https://coveralls.io/r/node-schedule/node-schedule?branch=master) [![Build Status](https://travis-ci.org/node-schedule/node-schedule.svg?branch=master)](https://travis-ci.org/node-schedule/node-schedule)
 
 [![NPM](https://nodei.co/npm/node-schedule.png?downloads=true)](https://nodei.co/npm/node-schedule/)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-schedule",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A cron-like and not-cron-like job scheduler for Node.",
   "keywords": ["schedule", "task", "job", "cron"],
   "main": "./lib/schedule.js",
@@ -18,12 +18,12 @@
     "url": "https://github.com/node-schedule/node-schedule.git"
   },
   "dependencies": {
-    "cron-parser": "~0.6.1",
-    "long-timeout": "~0.0.1"
+    "cron-parser": "0.6.1",
+    "long-timeout": "0.0.1"
   },
   "devDependencies": {
-    "eslint": "^0.15.1",
-    "nodeunit": "~0.8.1",
-    "sinon": "~1.12.2"
+    "eslint": "0.15.1",
+    "nodeunit": "0.9.1",
+    "sinon": "1.12.2"
   }
 }


### PR DESCRIPTION
Continuing from issue #54

I'm missing the tests but see if this make any sense, basically now you have a new API method `getJob`, which can be used internally to resolve and get the job and developers can use it as well when they just know the name of the job but not the index, for e.g.

```js
var schedule = require('node-schedule');

schedule.scheduleJob('test', '42 * * * *', function() {
    console.log('The answer to life, the universe, and everything!');
});

var jobTest = schedule.getJob('test');
```

So give me any feedback if this is the right path. If it is I'll make the tests for this, btw using `getJob`internally the current tests all have passed, so if there is tests to be done it will be for the new method `getJob` and the dilemma in the line 461.