### PR TITLE
update eslint rules to require all block statements to be wrapped in curly braces

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,10 +4,9 @@
   },
   "rules": {
     "eqeqeq": [2, "smart"],
-    "curly": [2, "multi-line"],
+    "indent": [2, 2],
     "no-constant-condition": false,
     "no-redeclare": 1,
-    "no-shadow": 1,
     "no-underscore-dangle": false,
     "no-use-before-define": [true,"nofunc"],
     "quotes": [2, "single"],

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -29,7 +29,9 @@ function Job() {
   }
 
   // give us a random name if one wasn't provided
-  if (name == null) name = '<Anonymous Job ' + (++anonJobCounter) + '>';
+  if (name == null) {
+    name = '<Anonymous Job ' + (++anonJobCounter) + '>';
+  }
 
   // setup a private pendingInvocations variable
   var pendingInvocations = [];
@@ -72,7 +74,9 @@ function Job() {
 
       if (reschedule && inv.recurrenceRule.recurs) {
         newInv = scheduleNextRecurrence(inv.recurrenceRule, this, inv.fireDate);
-        if (newInv !== null) newInvs.push(newInv);
+        if (newInv !== null) {
+          newInvs.push(newInv);
+        }
       }
     }
 
@@ -87,7 +91,9 @@ function Job() {
   this.cancelNext = function(reschedule) {
     reschedule = (typeof reschedule == 'boolean') ? reschedule : true;
 
-    if (!pendingInvocations.length) return false;
+    if (!pendingInvocations.length) {
+      return false;
+    }
 
     var newInv;
     var nextInv = pendingInvocations.shift();
@@ -96,13 +102,17 @@ function Job() {
 
     if (reschedule && nextInv.recurrenceRule.recurs) {
       newInv = scheduleNextRecurrence(nextInv.recurrenceRule, this, nextInv.fireDate);
-      if (newInv !== null) this.trackInvocation(newInv);
+      if (newInv !== null) {
+        this.trackInvocation(newInv);
+      }
     }
 
     return true;
   };
   this.nextInvocation = function() {
-    if (!pendingInvocations.length) return null;
+    if (!pendingInvocations.length) {
+      return null;
+    }
     return pendingInvocations[0].fireDate;
   };
   this.pendingInvocations = function() {
@@ -131,10 +141,15 @@ Job.prototype.schedule = function(spec) {
   try {
     var res = cronParser.parseExpression(spec);
     inv = scheduleNextRecurrence(res, self);
-    if (inv !== null) success = self.trackInvocation(inv);
+    if (inv !== null) {
+      success = self.trackInvocation(inv);
+    }
+
   } catch (err) {
     var type = typeof spec;
-    if (type === 'string') spec = new Date(spec);
+    if (type === 'string') {
+      spec = new Date(spec);
+    }
 
     if (spec instanceof Date) {
       inv = new Invocation(self, spec);
@@ -143,19 +158,35 @@ Job.prototype.schedule = function(spec) {
     } else if (type === 'object') {
       if (!(spec instanceof RecurrenceRule)) {
         var r = new RecurrenceRule();
-        if ('year' in spec) r.year = spec.year;
-        if ('month' in spec) r.month = spec.month;
-        if ('date' in spec) r.date = spec.date;
-        if ('dayOfWeek' in spec) r.dayOfWeek = spec.dayOfWeek;
-        if ('hour' in spec) r.hour = spec.hour;
-        if ('minute' in spec) r.minute = spec.minute;
-        if ('second' in spec) r.second = spec.second;
+        if ('year' in spec) {
+          r.year = spec.year;
+        }
+        if ('month' in spec) {
+          r.month = spec.month;
+        }
+        if ('date' in spec) {
+          r.date = spec.date;
+        }
+        if ('dayOfWeek' in spec) {
+          r.dayOfWeek = spec.dayOfWeek;
+        }
+        if ('hour' in spec) {
+          r.hour = spec.hour;
+        }
+        if ('minute' in spec) {
+          r.minute = spec.minute;
+        }
+        if ('second' in spec) {
+          r.second = spec.second;
+        }
 
         spec = r;
       }
 
       inv = scheduleNextRecurrence(spec, self);
-      if (inv !== null) success = self.trackInvocation(inv);
+      if (inv !== null) {
+        success = self.trackInvocation(inv);
+      }
     }
   }
 
@@ -203,7 +234,9 @@ Range.prototype.contains = function(val) {
     return (val >= this.start && val <= this.end);
   } else {
     for (var i = this.start; i < this.end; i += this.step) {
-      if (i === val) return true;
+      if (i === val) {
+        return true;
+      }
     }
 
     return false;
@@ -240,11 +273,15 @@ RecurrenceRule.prototype.validate = function() {
 RecurrenceRule.prototype.nextInvocationDate = function(base) {
   base = (base instanceof Date) ? base : (new Date());
   increment.addDateConvenienceMethods(base);
-  if (!this.recurs) return null;
+  if (!this.recurs) {
+    return null;
+  }
 
   var now = new Date();
   increment.addDateConvenienceMethods(now);
-  if (this.year !== null && (typeof this.year == 'number') && this.year < now.getFullYear()) return null;
+  if (this.year !== null && (typeof this.year == 'number') && this.year < now.getFullYear()) {
+    return null;
+  }
 
   var next = new Date(base.getTime());
   increment.addDateConvenienceMethods(next);
@@ -305,7 +342,9 @@ RecurrenceRule.prototype.nextInvocationDate = function(base) {
 };
 
 function recurMatch(val, matcher) {
-  if (matcher == null) return true;
+  if (matcher == null) {
+    return true;
+  }
 
   if (typeof matcher === 'number' || typeof matcher === 'string') {
     return (val === matcher);
@@ -313,7 +352,9 @@ function recurMatch(val, matcher) {
     return matcher.contains(val);
   } else if (Array.isArray(matcher) || (typeof matcher === 'object' && matcher instanceof Array)) {
     for (var i = 0; i < matcher.length; i++) {
-      if (recurMatch(val, matcher[i])) return true;
+      if (recurMatch(val, matcher[i])) {
+        return true;
+      }
     }
     return false;
   }
@@ -361,7 +402,9 @@ function prepareNextInvocation() {
 
       if (cinv.recurrenceRule.recurs || cinv.recurrenceRule._endDate === null) {
         var inv = scheduleNextRecurrence(cinv.recurrenceRule, cinv.job, cinv.fireDate);
-        if (inv !== null) inv.job.trackInvocation(inv);
+        if (inv !== null) {
+          inv.job.trackInvocation(inv);
+        }
       }
 
       job.stopTrackingInvocation(cinv);
@@ -382,9 +425,13 @@ function cancelInvocation(invocation) {
   var idx = invocations.indexOf(invocation);
   if (idx > -1) {
     invocations.splice(idx, 1);
-    if (invocation.timerID !== null) lt.clearTimeout(invocation.timerID);
+    if (invocation.timerID !== null) {
+      lt.clearTimeout(invocation.timerID);
+    }
 
-    if (currentInvocation === invocation) currentInvocation = null;
+    if (currentInvocation === invocation) {
+      currentInvocation = null;
+    }
 
     invocation.job.emit('canceled', invocation.fireDate);
     prepareNextInvocation();
@@ -396,7 +443,9 @@ function scheduleNextRecurrence(rule, job, prevDate) {
   prevDate = (prevDate instanceof Date) ? prevDate : (new Date());
 
   var date = (rule instanceof RecurrenceRule) ? rule.nextInvocationDate(prevDate) : rule.next();
-  if (date === null) return null;
+  if (date === null) {
+    return null;
+  }
 
   var inv = new Invocation(job, date, rule);
   scheduleInvocation(inv);
@@ -408,7 +457,9 @@ function scheduleNextRecurrence(rule, job, prevDate) {
 var scheduledJobs = {};
 
 function scheduleJob() {
-  if (arguments.length < 2) return null;
+  if (arguments.length < 2) {
+    return null;
+  }
 
   var name = (arguments.length >= 3) ? arguments[0] : null;
   var spec = (arguments.length >= 3) ? arguments[1] : arguments[0];
@@ -441,7 +492,9 @@ function cancelJob(job) {
   } else if (typeof job == 'string' || job instanceof String) {
     if (job in scheduledJobs && scheduledJobs.hasOwnProperty(job)) {
       success = scheduledJobs[job].cancel();
-      if (success) scheduledJobs[job] = null;
+      if (success) {
+        scheduledJobs[job] = null;
+      }
     }
   }
 


### PR DESCRIPTION
This change is per https://github.com/node-schedule/node-schedule/pull/112/files#r26470548. There were quite a few single line block statements that had to be updated to pass the linter. See http://eslint.org/docs/rules/curly.html and https://github.com/airbnb/javascript#blocks for some more info on this. Airbnb doesn't seem to address anything but multiline blocks. I also realized that the current linting rules weren't enforcing 2 space indentation, so I added that rule as well.

Let me know what you think.