### PR TITLE
Add validation for recurrence rules

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -403,22 +403,17 @@ function recurValidateProperty(val, min, max) {
     val = [val];
   }
 
-  if (typeof val === 'object' && val instanceof Array) {
-
-    for (var i = 0; i < val.length; i++) {
-      if (typeof val[i] !== 'number' && !(typeof val[i] === 'object' && val[i] instanceof Range)) {
-        return false;
-      } else if (typeof val[i] === 'number' && (val[i] < min || val[i] > max)) {
-        return false;
-      } else if (typeof val[i] === 'object' && val[i] instanceof Range && (val[i].start < min || val[i].end > max)) {
-        return false;
-      }
+  for (var i = 0; i < val.length; i++) {
+    if (typeof val[i] !== 'number' && !(typeof val[i] === 'object' && val[i] instanceof Range)) {
+      return false;
+    } else if (typeof val[i] === 'number' && (val[i] < min || val[i] > max)) {
+      return false;
+    } else if (typeof val[i] === 'object' && val[i] instanceof Range && (val[i].start < min || val[i].end > max)) {
+      return false;
     }
-
-    return true;
   }
 
-  return false;
+  return true;
 }
 
 /* Date-based scheduler */

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -266,41 +266,41 @@ function RecurrenceRule(year, month, date, dayOfWeek, hour, minute, second) {
 }
 
 RecurrenceRule.prototype.validate = function() {
+  var errorMessage = "Invalid RecurrenceRule: %s is not in allowed range";
+
   if (!recurValidateProperty(this.year, 0, Infinity)) {
-    return false;
+    throw new Error(util.format(errorMessage, 'year'));
   }
 
   if (!recurValidateProperty(this.month, 0, 11)) {
-    return false;
+    throw new Error(util.format(errorMessage, 'month'));
   }
 
   if (!recurValidateProperty(this.dayOfWeek, 0, 6)) {
-    return false;
+    throw new Error(util.format(errorMessage, 'dayOfWeek'));
   }
 
   if (!recurValidateProperty(this.date, 0, 30)) {
-    return false;
+    throw new Error(util.format(errorMessage, 'date'));
   }
 
   if (!recurValidateProperty(this.hour, 0, 23)) {
-    return false;
+    throw new Error(util.format(errorMessage, 'hour'));
   }
 
   if (!recurValidateProperty(this.minute, 0, 59)) {
-    return false;
+    throw new Error(util.format(errorMessage, 'minute'));
   }
 
   if (!recurValidateProperty(this.second, 0, 59)) {
-    return false;
+    throw new Error(util.format(errorMessage, 'second'));
   }
 
   return true;
 };
 
 RecurrenceRule.prototype.nextInvocationDate = function(base) {
-  if (!this.validate()) {
-    throw new Error('Invalid RecurrenceRule');
-  }
+  this.validate();
 
   base = (base instanceof Date) ? base : (new Date());
   increment.addDateConvenienceMethods(base);
@@ -404,11 +404,13 @@ function recurValidateProperty(val, min, max) {
   }
 
   for (var i = 0; i < val.length; i++) {
-    if (typeof val[i] !== 'number' && !(typeof val[i] === 'object' && val[i] instanceof Range)) {
+    var valType = typeof val[i];
+
+    if (valType !== 'number' && !(val[i] instanceof Range)) {
       return false;
-    } else if (typeof val[i] === 'number' && (val[i] < min || val[i] > max)) {
+    } else if (valType === 'number' && (val[i] < min || val[i] > max)) {
       return false;
-    } else if (typeof val[i] === 'object' && val[i] instanceof Range && (val[i].start < min || val[i].end > max)) {
+    } else if (val[i] instanceof Range && (val[i].start < min || val[i].end > max)) {
       return false;
     }
   }

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -266,7 +266,7 @@ function RecurrenceRule(year, month, date, dayOfWeek, hour, minute, second) {
 }
 
 RecurrenceRule.prototype.validate = function() {
-  var errorMessage = "Invalid RecurrenceRule: %s is not in allowed range";
+  var errorMessage = 'Invalid RecurrenceRule: %s is not in allowed range';
 
   if (!recurValidateProperty(this.year, 0, Infinity)) {
     throw new Error(util.format(errorMessage, 'year'));

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -266,11 +266,42 @@ function RecurrenceRule(year, month, date, dayOfWeek, hour, minute, second) {
 }
 
 RecurrenceRule.prototype.validate = function() {
-  // TODO: validation
+  if (!recurValidateProperty(this.year, 0, Infinity)) {
+    return false;
+  }
+
+  if (!recurValidateProperty(this.month, 0, 11)) {
+    return false;
+  }
+
+  if (!recurValidateProperty(this.dayOfWeek, 0, 6)) {
+    return false;
+  }
+
+  if (!recurValidateProperty(this.date, 0, 30)) {
+    return false;
+  }
+
+  if (!recurValidateProperty(this.hour, 0, 23)) {
+    return false;
+  }
+
+  if (!recurValidateProperty(this.minute, 0, 59)) {
+    return false;
+  }
+
+  if (!recurValidateProperty(this.second, 0, 59)) {
+    return false;
+  }
+
   return true;
 };
 
 RecurrenceRule.prototype.nextInvocationDate = function(base) {
+  if (!this.validate()) {
+    throw new Error('Invalid RecurrenceRule');
+  }
+
   base = (base instanceof Date) ? base : (new Date());
   increment.addDateConvenienceMethods(base);
   if (!this.recurs) {
@@ -357,6 +388,34 @@ function recurMatch(val, matcher) {
       }
     }
     return false;
+  }
+
+  return false;
+}
+
+function recurValidateProperty(val, min, max) {
+  if (val === null) {
+    return true;
+  }
+
+  // wrap in array
+  if (!(val instanceof Array)) {
+    val = [val];
+  }
+
+  if (typeof val === 'object' && val instanceof Array) {
+
+    for (var i = 0; i < val.length; i++) {
+      if (typeof val[i] !== 'number' && !(typeof val[i] === 'object' && val[i] instanceof Range)) {
+        return false;
+      } else if (typeof val[i] === 'number' && (val[i] < min || val[i] > max)) {
+        return false;
+      } else if (typeof val[i] === 'object' && val[i] instanceof Range && (val[i].start < min || val[i].end > max)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   return false;

--- a/test/recurrence-rule-test.js
+++ b/test/recurrence-rule-test.js
@@ -34,10 +34,16 @@ module.exports = {
       test.done();
     },
     "next 60th second (minutes incremented)": function(test) {
+      test.expect(1);
+
       var rule = new schedule.RecurrenceRule();
       rule.second = 60;
 
-      test.throws(function() {rule.nextInvocationDate(base);});
+      try {
+        rule.nextInvocationDate(base);
+      } catch (err) {
+        test.equal('Invalid RecurrenceRule: second is not in allowed range', err.message);
+      }
 
       test.done();
     },
@@ -51,10 +57,16 @@ module.exports = {
       test.done();
     },
     "next 60th minute": function(test) {
+      test.expect(1);
+
       var rule = new schedule.RecurrenceRule();
       rule.minute = 60;
 
-      test.throws(function() {rule.nextInvocationDate(base);});
+      try {
+        rule.nextInvocationDate(base);
+      } catch (err) {
+        test.equal('Invalid RecurrenceRule: minute is not in allowed range', err.message);
+      }
 
       test.done();
     },
@@ -77,10 +89,16 @@ module.exports = {
       test.done();
     },
     "next 24th hour should throw error": function(test) {
+      test.expect(1);
+
       var rule = new schedule.RecurrenceRule();
       rule.hour = 24;
 
-      test.throws(function() {rule.nextInvocationDate(base);});
+      try {
+        rule.nextInvocationDate(base);
+      } catch (err) {
+        test.equal('Invalid RecurrenceRule: hour is not in allowed range', err.message);
+      }
 
       test.done();
     },
@@ -103,10 +121,16 @@ module.exports = {
       test.done();
     },
     "next 7th day should throw error": function(test) {
+      test.expect(1);
+
       var rule = new schedule.RecurrenceRule();
       rule.dayOfWeek = 7;
 
-      test.throws(function() {rule.nextInvocationDate(base);});
+      try {
+        rule.nextInvocationDate(base);
+      } catch (err) {
+        test.equal('Invalid RecurrenceRule: dayOfWeek is not in allowed range', err.message);
+      }
 
       test.done();
     },
@@ -129,10 +153,16 @@ module.exports = {
       test.done();
     },
     "next 31st date should throw error": function(test) {
+      test.expect(1);
+
       var rule = new schedule.RecurrenceRule();
       rule.date = 31;
 
-      test.throws(function() {rule.nextInvocationDate(base);});
+      try {
+        rule.nextInvocationDate(base);
+      } catch (err) {
+        test.equal('Invalid RecurrenceRule: date is not in allowed range', err.message);
+      }
 
       test.done();
     },
@@ -155,10 +185,16 @@ module.exports = {
       test.done();
     },
     "next invalid month should throw error": function(test) {
+      test.expect(1);
+
       var rule = new schedule.RecurrenceRule();
       rule.month = 12;
 
-      test.throws(function() {rule.nextInvocationDate(base);});
+      try {
+        rule.nextInvocationDate(base);
+      } catch (err) {
+        test.equal('Invalid RecurrenceRule: month is not in allowed range', err.message);
+      }
 
       test.done();
     },
@@ -190,10 +226,16 @@ module.exports = {
       test.done();
     },
     "invalid year should throw error": function(test) {
+      test.expect(1);
+
       var rule = new schedule.RecurrenceRule();
       rule.year = -30;
 
-      test.throws(function() {rule.nextInvocationDate(base);});
+      try {
+        rule.nextInvocationDate(base);
+      } catch (err) {
+        test.equal('Invalid RecurrenceRule: year is not in allowed range', err.message);
+      }
 
       test.done();
     },
@@ -294,26 +336,44 @@ module.exports = {
       test.done();
     },
     "specify span and explicit components using Array of bad Ranges and Numbers": function(test) {
+      test.expect(1);
+
       var rule = new schedule.RecurrenceRule();
       rule.minute = [2, new schedule.Range(4, 60)];
 
-      test.throws(function() {rule.nextInvocationDate(base);});
+      try {
+        rule.nextInvocationDate(base);
+      } catch (err) {
+        test.equal('Invalid RecurrenceRule: minute is not in allowed range', err.message);
+      }
 
       test.done();
     },
     "specify span and explicit components using Array of Ranges and Bad Numbers": function(test) {
+      test.expect(1);
+      
       var rule = new schedule.RecurrenceRule();
       rule.minute = [1, new schedule.Range(4, 6), 60];
 
-      test.throws(function() {rule.nextInvocationDate(base);});
+      try {
+        rule.nextInvocationDate(base);
+      } catch (err) {
+        test.equal('Invalid RecurrenceRule: minute is not in allowed range', err.message);
+      }
 
       test.done();
     },
     "specify span and explicit components using Array of Ranges and Invalid Types": function(test) {
+      test.expect(1);
+      
       var rule = new schedule.RecurrenceRule();
       rule.minute = ['test', new schedule.Range(4, 6), {bad: 'value'}];
 
-      test.throws(function() {rule.nextInvocationDate(base);});
+      try {
+        rule.nextInvocationDate(base);
+      } catch (err) {
+        test.equal('Invalid RecurrenceRule: minute is not in allowed range', err.message);
+      }
 
       test.done();
     }

--- a/test/recurrence-rule-test.js
+++ b/test/recurrence-rule-test.js
@@ -60,6 +60,14 @@ module.exports = {
       test.deepEqual(new Date(2010, 3, 29, 23, 0, 0, 0), next);
       test.done();
     },
+    "next 24th hour should throw error": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.hour = 24;
+
+      test.throws(function() {rule.nextInvocationDate(base);});
+
+      test.done();
+    },
     "next 3rd hour (days incremented)": function(test) {
       var rule = new schedule.RecurrenceRule();
       rule.hour = 3;

--- a/test/recurrence-rule-test.js
+++ b/test/recurrence-rule-test.js
@@ -33,6 +33,14 @@ module.exports = {
       test.deepEqual(new Date(2010, 3, 29, 12, 31, 5, 0), next);
       test.done();
     },
+    "next 60th second (minutes incremented)": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.second = 60;
+
+      test.throws(function() {rule.nextInvocationDate(base);});
+
+      test.done();
+    },
     "next 40th minute": function(test) {
       var rule = new schedule.RecurrenceRule();
       rule.minute = 40;
@@ -40,6 +48,14 @@ module.exports = {
       var next = rule.nextInvocationDate(base);
 
       test.deepEqual(new Date(2010, 3, 29, 12, 40, 0, 0), next);
+      test.done();
+    },
+    "next 60th minute": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.minute = 60;
+
+      test.throws(function() {rule.nextInvocationDate(base);});
+
       test.done();
     },
     "next 1st minute (hours incremented)": function(test) {
@@ -86,6 +102,14 @@ module.exports = {
       test.deepEqual(new Date(2010, 3, 30, 0, 0, 0, 0), next);
       test.done();
     },
+    "next 7th day should throw error": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.dayOfWeek = 7;
+
+      test.throws(function() {rule.nextInvocationDate(base);});
+
+      test.done();
+    },
     "next Monday (months incremented)": function(test) {
       var rule = new schedule.RecurrenceRule();
       rule.dayOfWeek = 1;
@@ -104,6 +128,14 @@ module.exports = {
       test.deepEqual(new Date(2010, 3, 30, 0, 0, 0, 0), next);
       test.done();
     },
+    "next 31st date should throw error": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.date = 31;
+
+      test.throws(function() {rule.nextInvocationDate(base);});
+
+      test.done();
+    },
     "next 5th date (months incremented)": function(test) {
       var rule = new schedule.RecurrenceRule();
       rule.date = 5;
@@ -120,6 +152,14 @@ module.exports = {
       var next = rule.nextInvocationDate(base);
 
       test.deepEqual(new Date(2010, 9, 1, 0, 0, 0, 0), next);
+      test.done();
+    },
+    "next invalid month should throw error": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.month = 12;
+
+      test.throws(function() {rule.nextInvocationDate(base);});
+
       test.done();
     },
     "next February (years incremented)": function(test) {
@@ -147,6 +187,14 @@ module.exports = {
       var next = rule.nextInvocationDate(base);
 
       test.equal(null, next);
+      test.done();
+    },
+    "invalid year should throw error": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.year = -30;
+
+      test.throws(function() {rule.nextInvocationDate(base);});
+
       test.done();
     },
     "using mixed time components": function(test) {
@@ -242,6 +290,30 @@ module.exports = {
 
       next = rule.nextInvocationDate(next);
       test.deepEqual(new Date(2010, 3, 29, 14, 2, 0, 0), next);
+
+      test.done();
+    },
+    "specify span and explicit components using Array of bad Ranges and Numbers": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.minute = [2, new schedule.Range(4, 60)];
+
+      test.throws(function() {rule.nextInvocationDate(base);});
+
+      test.done();
+    },
+    "specify span and explicit components using Array of Ranges and Bad Numbers": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.minute = [1, new schedule.Range(4, 6), 60];
+
+      test.throws(function() {rule.nextInvocationDate(base);});
+
+      test.done();
+    },
+    "specify span and explicit components using Array of Ranges and Invalid Types": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.minute = ['test', new schedule.Range(4, 6), {bad: 'value'}];
+
+      test.throws(function() {rule.nextInvocationDate(base);});
 
       test.done();
     }


### PR DESCRIPTION
This takes care of https://github.com/node-schedule/node-schedule/issues/108 and will prevent things like https://github.com/node-schedule/node-schedule/issues/121 from happening. Throws error if not valid. Validation runs at the beginning of next invocation. @tejasmanohar and @santigimeno, what do you think?