### PR TITLE
Remove unnecessary checks for object

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -348,9 +348,9 @@ function recurMatch(val, matcher) {
 
   if (typeof matcher === 'number' || typeof matcher === 'string') {
     return (val === matcher);
-  } else if (typeof matcher === 'object' && matcher instanceof Range) {
+  } else if (matcher instanceof Range) {
     return matcher.contains(val);
-  } else if (Array.isArray(matcher) || (typeof matcher === 'object' && matcher instanceof Array)) {
+  } else if (Array.isArray(matcher) || (matcher instanceof Array)) {
     for (var i = 0; i < matcher.length; i++) {
       if (recurMatch(val, matcher[i])) {
         return true;


### PR DESCRIPTION
No need to check if it's an object just to check if it is an instanceof