### PR TITLE
Remove recurrence validate function since it is not being used

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -265,11 +265,6 @@ function RecurrenceRule(year, month, date, dayOfWeek, hour, minute, second) {
   this.second = (second == null) ? 0 : second;
 }
 
-RecurrenceRule.prototype.validate = function() {
-  // TODO: validation
-  return true;
-};
-
 RecurrenceRule.prototype.nextInvocationDate = function(base) {
   base = (base instanceof Date) ? base : (new Date());
   increment.addDateConvenienceMethods(base);


### PR DESCRIPTION
And is already being tracked as an issue. Especially since this is going to have to wait until the next major version to implement. No point in having code that is not being used. In addition, since this method can be hit publicly, it could falsely return true for someone.