### PR TITLE
src: RecurrenceRule bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/node-schedule/node-schedule.git"
   },
   "dependencies": {
-    "cron-parser": "0.6.1",
+    "cron-parser": "0.6.2",
     "long-timeout": "0.0.2"
   },
   "devDependencies": {

--- a/test/recurrence-rule-test.js
+++ b/test/recurrence-rule-test.js
@@ -236,6 +236,25 @@ module.exports = {
       test.deepEqual(new Date(2010, 3, 29, 14, 2, 0, 0), next);
 
       test.done();
+    },
+    "From 31th May schedule the 1st of every June": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.second = 0;
+      rule.minute = 0;
+      rule.hour = 0;
+      rule.date = 1;
+      rule.month = 5;
+
+      var next;
+      var base1 = new Date(2010, 4, 31, 12, 30, 15, 0);
+
+      next = rule.nextInvocationDate(base1);
+      test.deepEqual(new Date(2010, 5, 1, 0, 0, 0, 0), next);
+
+      next = rule.nextInvocationDate(next);
+      test.deepEqual(new Date(2011, 5, 1, 0, 0, 0, 0), next);
+
+      test.done();
     }
   }
 };


### PR DESCRIPTION
- Adding 1 month from the 31st day of a month that is followed by a less than
  31-day month, sets the Date to the first day if the following following month.
  For example: if the base Date is the 31st of May, calling addMonth, sets the
  date to the 1st of July instead of the 1st of June.
- Fixed by upgrading to cron-parser@0.6.2
- New test added.