### PR TITLE
src: remove unneeded code from nextInvocationDate

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -303,35 +303,22 @@ RecurrenceRule.prototype.nextInvocationDate = function(base) {
     }
     if (this.month != null && !recurMatch(next.getMonth(), this.month)) {
       next.addMonth();
-      next.setDate(1);
-      next.setHours(0);
-      next.setMinutes(0);
-      next.setSeconds(0);
       continue;
     }
     if (this.date != null && !recurMatch(next.getDate(), this.date)) {
       next.addDay();
-      next.setHours(0);
-      next.setMinutes(0);
-      next.setSeconds(0);
       continue;
     }
     if (this.dayOfWeek != null && !recurMatch(next.getDay(), this.dayOfWeek)) {
       next.addDay();
-      next.setHours(0);
-      next.setMinutes(0);
-      next.setSeconds(0);
       continue;
     }
     if (this.hour != null && !recurMatch(next.getHours(), this.hour)) {
       next.addHour();
-      next.setMinutes(0);
-      next.setSeconds(0);
       continue;
     }
     if (this.minute != null && !recurMatch(next.getMinutes(), this.minute)) {
       next.addMinute();
-      next.setSeconds(0);
       continue;
     }
     if (this.second != null && !recurMatch(next.getSeconds(), this.second)) {


### PR DESCRIPTION
- As it's already implemented in cron-parser date.js.