### PR TITLE
Cope with cron formats that cause errors.

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -223,7 +223,15 @@ function Invocation(job, fireDate, recurrenceRule) {
 }
 
 function sorter(a, b) {
-  return (a.fireDate.getTime() - b.fireDate.getTime());
+  var aTime = a.fireDate.getTime();
+  var bTime = b.fireDate.getTime();
+  if (isNaN(aTime)) {
+    return 1; // a seems to have an invalid date. Put it at the end.
+  }
+  if (isNaN(bTime)) {
+    return -1; // b seems to have an invalid date. Put it at the end.
+  }
+  return (aTime - bTime);
 }
 
 /* Range object */

--- a/test/schedule-cron-jobs.js
+++ b/test/schedule-cron-jobs.js
@@ -128,6 +128,23 @@ module.exports = {
 
       clock.tick(timeout);
     },
+    "Cope with invalid cron spec": function(test) {
+      test.expect(2);
+      var timeout = 1 * 24 * 60 * 60 * 1000;
+      var job1 = schedule.scheduleJob('0 0 0 * * *',function(){test.ok(true);});
+      var job2 = schedule.scheduleJob('error',function(){test.ok(true);});
+      var job3 = schedule.scheduleJob('0 2 0 * * *',function(){test.ok(true);});
+
+      setTimeout(function() {
+        job1.cancel();
+        job2.cancel();
+        job3.cancel();
+        test.done();
+      }, timeout);
+
+      clock.tick(timeout);
+
+    },
     tearDown: function(cb) {
       clock.restore();
       cb();


### PR DESCRIPTION
Hi,

Thanks for your work on node-schedule.

I use it to schedule several jobs using cron formats. I found that if one of the jobs has an invalid cron format, jobs that are added afterwards are not invoked. If I sorted the list of invocations so that invalid dates were moved to the end, the error's influence remains localised to that job, rather than affecting others.

Regards,

John.