### PR TITLE
Add support for generators

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -32,6 +32,13 @@ function Job(name, job, callback) {
     this.callback = typeof callback === 'function' ? callback : false;
   }
 
+  // Check for generator
+  if (typeof this.job === 'function' && this.job.prototype.next) {
+    this.job = function() {
+      return this.next().value;
+    }.bind(this.job());
+  }
+
   // define properties
   Object.defineProperty(this, 'name', {
     value: jobName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-schedule",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A cron-like and not-cron-like job scheduler for Node.",
   "keywords": [
     "schedule",

--- a/test/es6/job-test.js
+++ b/test/es6/job-test.js
@@ -1,0 +1,20 @@
+
+'use strict';
+
+module.exports = function(schedule) {
+  return {
+    jobInGenerator: function(test) {
+      test.expect(1);
+
+      var job = new schedule.Job(function*() {
+        test.ok(true);
+      });
+
+      job.runOnDate(new Date(Date.now() + 3000));
+
+      setTimeout(function() {
+        test.done();
+      }, 3250);
+    }
+  }
+}

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -5,6 +5,12 @@ var sinon = require('sinon');
 var main = require('../package.json').main;
 var schedule = require('../' + main);
 
+var supportsGenerators = false;
+try {
+  eval('(function* () {})()');
+  supportsGenerators = true;
+} catch (e) {}
+
 var clock;
 
 module.exports = {
@@ -69,6 +75,27 @@ module.exports = {
       test.expect(1);
 
       var job = new schedule.Job(function() {
+        test.ok(true);
+      });
+
+      job.runOnDate(new Date(Date.now() + 3000));
+
+      setTimeout(function() {
+        test.done();
+      }, 3250);
+
+      clock.tick(3250);
+    },
+    "Run job in generator": function(test) {
+      if (!supportsGenerators) {
+        test.expect(0);
+        test.done();
+        return;
+      }
+
+      test.expect(1);
+
+      var job = new schedule.Job(function*() {
         test.ok(true);
       });
 

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -5,10 +5,10 @@ var sinon = require('sinon');
 var main = require('../package.json').main;
 var schedule = require('../' + main);
 
-var supportsGenerators = false;
+var es6;
 try {
   eval('(function* () {})()');
-  supportsGenerators = true;
+  es6 = require('./es6/job-test')(schedule);
 } catch (e) {}
 
 var clock;
@@ -87,23 +87,13 @@ module.exports = {
       clock.tick(3250);
     },
     "Run job in generator": function(test) {
-      if (!supportsGenerators) {
+      if (!es6) {
         test.expect(0);
         test.done();
         return;
       }
 
-      test.expect(1);
-
-      var job = new schedule.Job(function*() {
-        test.ok(true);
-      });
-
-      job.runOnDate(new Date(Date.now() + 3000));
-
-      setTimeout(function() {
-        test.done();
-      }, 3250);
+      es6.jobInGenerator(test);
 
       clock.tick(3250);
     },


### PR DESCRIPTION
This patch adds support for ES6 generators, without introducing any issues for older versions of node that don't support them.

It allows the use case like the following:

```javascript
schedule.scheduleJob('someJob', someDate, function*() {
  const record = yield mongoose.model('Foo').findOne(someitem).exec();
  doStuffTo(record);
});
```