### PR TITLE
Add support for job functions with bound scope

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -33,7 +33,8 @@ function Job(name, job, callback) {
   }
 
   // Check for generator
-  if (typeof this.job === 'function' && this.job.prototype.next) {
+  var isGenerator = typeof this.job === 'function' && typeof this.job.prototype !== 'undefined' && this.job.prototype.next;
+  if (isGenerator) {
     this.job = function() {
       return this.next().value;
     }.bind(this.job());

--- a/test/convenience-method-test.js
+++ b/test/convenience-method-test.js
@@ -36,6 +36,19 @@ module.exports = {
 
       clock.tick(3250);
     },
+    "Runs job once at some date with a bound function": function (test) {
+      test.expect(1);
+
+      schedule.scheduleJob(new Date(Date.now() + 3000), function() {
+        test.ok(this === null);
+      }.bind(null));
+
+      setTimeout(function() {
+        test.done();
+      }, 3250);
+
+      clock.tick(3250);
+    },
     "Job doesn't emit initial 'scheduled' event": function(test) {
         var job = schedule.scheduleJob(new Date(Date.now() + 1000), function() {});
 


### PR DESCRIPTION
Hi,

I ran into a problem today while trying to use the library with bound job functions. 

As per the ECMAScript 5.1 standard when using `Function.prototype.bind` the resulting function does not get a prototype and thus the library will fail when trying to check if the function is a generator (which it does by checking the prototype).

This code would fail:
```
var scheduler = require('node-schedule');
scheduler.scheduleJob('* * * * *', function () {
    // do something with this
}.bind(myObject));
```

I've added a test case which failed in the old situation and passes in the new one, where an extra check is added to check for the prototype itself.

Kind regards,

Bas Tuijnman