### PR TITLE
Fix generator detection edge case

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -33,10 +33,12 @@ function Job(name, job, callback) {
   }
 
   // Check for generator
-  if (typeof this.job === 'function' && this.job.prototype.next) {
+  if (typeof this.job === 'function' &&
+      this.job.prototype &&
+      this.job.prototype.next) {
     this.job = function() {
       return this.next().value;
-    }.bind(this.job());
+    }.bind(this.job.call(this));
   }
 
   // define properties

--- a/test/es6/job-test.js
+++ b/test/es6/job-test.js
@@ -15,6 +15,19 @@ module.exports = function(schedule) {
       setTimeout(function() {
         test.done();
       }, 3250);
+    },
+    jobContextInGenerator: function(test) {
+      test.expect(1);
+
+      var job = new schedule.Job('name of job', function*() {
+        test.ok(this.name === 'name of job');
+      });
+
+      job.runOnDate(new Date(Date.now() + 3000));
+
+      setTimeout(function() {
+        test.done();
+      }, 3250);
     }
   }
 }

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -97,6 +97,17 @@ module.exports = {
 
       clock.tick(3250);
     },
+    "Context is passed into generator correctly": function(test) {
+      if (!es6) {
+        test.expect(0);
+        test.done();
+        return;
+      }
+
+      es6.jobContextInGenerator(test);
+
+      clock.tick(3250);
+    },
     /* No jobs will run after this test for some reason - hide for now
     "Won't run job if scheduled in the past": function(test) {
       test.expect(0);


### PR DESCRIPTION
If you do something odd like `function*(){}.bind(this)`, the use of `.bind` causes the resultant function to not have a `prototype` property *at all*. ಠ_ಠ

Note I've already incremented the patch version in the `package.json`.