### PR TITLE
Fixed scheduleJob not working on leap year. #229

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/node-schedule/node-schedule.git"
   },
   "dependencies": {
-    "cron-parser": "0.6.2",
+    "cron-parser": "1.1.0",
     "long-timeout": "0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated the dependency, cron-parser, to 1.1.0.
https://github.com/node-schedule/node-schedule/issues/229