### PR TITLE
Fix memory Leak

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -100,7 +100,7 @@ function Job(name, job, callback) {
     // remove from scheduledJobs if reschedule === false
     if (!reschedule) {
       if (this.name) {
-        scheduledJobs[this.name] = null;
+        delete scheduledJobs[this.name];
       }
     }
 

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -410,13 +410,13 @@ module.exports = {
                                       function() {},
                                       function() {});
 
-      test.equal(schedule.scheduledJobs.cancelJob, job1);
-      test.equal(schedule.scheduledJobs.second, job2);
+      test.strictEqual(schedule.scheduledJobs.cancelJob, job1);
+      test.strictEqual(schedule.scheduledJobs.second, job2);
       setTimeout(function() {
         job1.cancel();
         job2.cancel();
-        test.equal(schedule.scheduledJobs.cancelJob, null);
-        test.equal(schedule.scheduledJobs.second, null);
+        test.strictEqual(schedule.scheduledJobs.cancelJob, undefined);
+        test.strictEqual(schedule.scheduledJobs.second, undefined);
         test.done();
       }, 1250);
 


### PR DESCRIPTION
When a schedule is canceled without reschedule, its instant is removed from the list but the name of the instance was remaining.

After some added and canceled jobs, the list was full of null values.