### PR TITLE
bump cron-parser to v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/node-schedule/node-schedule.git"
   },
   "dependencies": {
-    "cron-parser": "0.6.2",
+    "cron-parser": "1.1.0",
     "long-timeout": "0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
older versions have a bug in a leap month, easy fix is to bump the `cron-parser` version to 1.1.0.