### PR TITLE
Draws more attention to recurrence rule default values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,10 @@ var j = schedule.scheduleJob(rule, function(){
 });
 ```
 
-It's worth noting that the default value of a component of a recurrence rule is
-`null` (except for seconds, which is 0 for familiarity with cron). If we did not
+> **Note**: It's worth noting that the default value of a component of a recurrence rule is
+`null` (except for seconds, which is 0 for familiarity with cron). *If we did not
 explicitly set `minute` to 0 above, the message would have instead been logged at
-5:00pm, 5:01pm, 5:02pm, ..., 5:59pm. Probably not what you want.
+5:00pm, 5:01pm, 5:02pm, ..., 5:59pm.* Probably not what you want.
 
 #### Object Literal Syntax
 


### PR DESCRIPTION
This is a **very minor** patch to the README, spurred from my own experience with missing the affected line when making a recurrence rule. My update just draws more attention to that last bit where you explain that if you don't explicitly set the minute value to 0, the job will be executed every minute of the hour.