### PR TITLE
Properly parse RecurrenceRule that contains string properties

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -410,8 +410,10 @@ function recurMatch(val, matcher) {
     return true;
   }
 
-  if (typeof matcher === 'number' || typeof matcher === 'string') {
+  if (typeof matcher === 'number') {
     return (val === matcher);
+  } else if(typeof matcher === 'string') {
+    return (val === Number(matcher));
   } else if (matcher instanceof Range) {
     return matcher.contains(val);
   } else if (Array.isArray(matcher) || (matcher instanceof Array)) {

--- a/test/recurrence-rule-test.js
+++ b/test/recurrence-rule-test.js
@@ -289,6 +289,17 @@ module.exports = {
       test.equal(next, null);
 
       test.done();
+    },
+    "using rule with string properties": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.second = '50';
+      rule.minute = '5';
+      rule.hour = '10';
+
+      var next = rule.nextInvocationDate(base);
+
+      test.deepEqual(new Date(2010, 3, 30, 10, 5, 50, 0), next);
+      test.done();
     }
   }
 };


### PR DESCRIPTION
Before,
```
const rule = new schedule.RecurrenceRule();
rule.second = '0';`
const j = schedule.scheduleJob(rule, function(){
  console.log('Hello');
});
```
results in an infinite loop, because recurMatch was comparing a string to numbers using === .

The change makes it so that it will parse any string properties using Number().  The above code would now work as I would expect it to, printing hello at the top of every minute.

Bonus Question:  Is there a reason the rule input is never checked for validity?  I feel it would be reasonable to throw an error if a user tries to do something like 'rule.second = 60'.