### PR TITLE
src: improve performance when sorting invocations

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -10,7 +10,8 @@ var events = require('events'),
   util = require('util'),
   cronParser = require('cron-parser'),
   CronDate = require('cron-parser/lib/date'),
-  lt = require('long-timeout');
+  lt = require('long-timeout'),
+  sorted = require('sorted-array-functions');
 
 /* Job object */
 var anonJobCounter = 0;
@@ -60,11 +61,7 @@ function Job(name, job, callback) {
   // method that require private access
   this.trackInvocation = function(invocation) {
     // add to our invocation list
-    pendingInvocations.push(invocation);
-
-    // and sort
-    pendingInvocations.sort(sorter);
-
+    sorted.add(pendingInvocations, invocation, sorter);
     return true;
   };
   this.stopTrackingInvocation = function(invocation) {
@@ -442,8 +439,7 @@ var invocations = [];
 var currentInvocation = null;
 
 function scheduleInvocation(invocation) {
-  invocations.push(invocation);
-  invocations.sort(sorter);
+  sorted.add(invocations, invocation, sorter);
   prepareNextInvocation();
   invocation.job.emit('scheduled', invocation.fireDate);
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "cron-parser": "1.1.0",
-    "long-timeout": "0.1.1"
+    "long-timeout": "0.1.1",
+    "sorted-array-functions": "^1.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
Using `sorted-array-functions` to sort the invocation arrays, improve
the module performance greatly when scheduling lots (thousands) of jobs.

Fixes: https://github.com/node-schedule/node-schedule/issues/333