### PR TITLE
deps: upgrade to cron-parser@2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "0.12"
   - "0.10"
   - "4"
-  - "5"
+  - "6"
+  - "7"
 before_script: npm run lint
 script: ./node_modules/.bin/istanbul cover ./node_modules/.bin/nodeunit test && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls && rm -rf ./coverage

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -185,33 +185,40 @@ Job.prototype.schedule = function(spec) {
   var inv;
   var start;
   var end;
+  var tz;
 
   if (typeof spec === 'object' && spec.rule) {
-    start = spec.start || null;
-    end = spec.end || null;
+    start = spec.start || undefined;
+    end = spec.end || undefined;
     spec = spec.rule;
+    tz = spec.tz;
 
-    if (start != null) {
+    if (start) {
       if (!(start instanceof Date)) {
         start = new Date(start);
       }
+
+      start = new CronDate(start, tz);
       if (!isValidDate(start) || start.getTime() < Date.now()) {
-        start = null;
+        start = undefined;
       }
     }
 
-    if (end != null && !(end instanceof Date) && !isValidDate(end = new Date(end))) {
-      end = null;
+    if (end && !(end instanceof Date) && !isValidDate(end = new Date(end))) {
+      end = undefined;
+    }
+
+    if (end) {
+      end = new CronDate(end, tz);
     }
   }
 
   try {
-    var res = cronParser.parseExpression(spec, { currentDate: start });
+    var res = cronParser.parseExpression(spec, { currentDate: start, tz: tz });
     inv = scheduleNextRecurrence(res, self, start, end);
     if (inv !== null) {
       success = self.trackInvocation(inv);
     }
-
   } catch (err) {
     var type = typeof spec;
     if ((type === 'string') || (type === 'number')) {
@@ -219,6 +226,7 @@ Job.prototype.schedule = function(spec) {
     }
 
     if ((spec instanceof Date) && (isValidDate(spec))) {
+      spec = new CronDate(spec);
       if (spec.getTime() >= Date.now()) {
         inv = new Invocation(self, spec);
         scheduleInvocation(inv);
@@ -252,6 +260,7 @@ Job.prototype.schedule = function(spec) {
         spec = r;
       }
 
+      spec.tz = tz;
       inv = scheduleNextRecurrence(spec, self, start, end);
       if (inv !== null) {
         success = self.trackInvocation(inv);
@@ -337,12 +346,12 @@ function RecurrenceRule(year, month, date, dayOfWeek, hour, minute, second) {
 }
 
 RecurrenceRule.prototype.nextInvocationDate = function(base) {
-  base = (base instanceof Date) ? base : (new Date());
+  base = ((base instanceof CronDate) || (base instanceof Date)) ? base : (new Date());
   if (!this.recurs) {
     return null;
   }
 
-  var now = new Date();
+  var now = new CronDate(Date.now(), this.tz);
   var fullYear = now.getFullYear();
   if ((this.year !== null) &&
       (typeof this.year == 'number') &&
@@ -350,7 +359,7 @@ RecurrenceRule.prototype.nextInvocationDate = function(base) {
     return null;
   }
 
-  var next = new CronDate(base.getTime());
+  var next = new CronDate(base.getTime(), this.tz);
   next.addSecond();
 
   while (true) {
@@ -399,7 +408,7 @@ RecurrenceRule.prototype.nextInvocationDate = function(base) {
     break;
   }
 
-  return next;
+  return next ? next.toDate() : null;
 };
 
 function recurMatch(val, matcher) {
@@ -443,7 +452,8 @@ var currentInvocation = null;
 function scheduleInvocation(invocation) {
   sorted.add(invocations, invocation, sorter);
   prepareNextInvocation();
-  invocation.job.emit('scheduled', invocation.fireDate);
+  var date = invocation.fireDate instanceof CronDate ? invocation.fireDate.toDate() : invocation.fireDate;
+  invocation.job.emit('scheduled', date);
 }
 
 function prepareNextInvocation() {
@@ -506,14 +516,14 @@ function cancelInvocation(invocation) {
 /* Recurrence scheduler */
 function scheduleNextRecurrence(rule, job, prevDate, endDate) {
 
-  prevDate = (prevDate instanceof Date) ? prevDate : (new Date());
+  prevDate = (prevDate instanceof CronDate) ? prevDate : new CronDate();
 
   var date = (rule instanceof RecurrenceRule) ? rule.nextInvocationDate(prevDate) : rule.next();
   if (date === null) {
     return null;
   }
 
-  if ((endDate instanceof Date) && date.getTime() > endDate.getTime()) {
+  if ((endDate instanceof CronDate) && date.getTime() > endDate.getTime()) {
     return null;
   }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/node-schedule/node-schedule.git"
   },
   "dependencies": {
-    "cron-parser": "1.1.0",
+    "cron-parser": "^2.4.0",
     "long-timeout": "0.1.1",
     "sorted-array-functions": "^1.0.0"
   },

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -154,7 +154,7 @@ module.exports = {
       });
 
       job.on('scheduled', function(runAtDate) {
-        test.equal(runAtDate, date);
+        test.equal(runAtDate.getTime(), date.getTime());
       });
 
       job.schedule(date);

--- a/test/schedule-cron-jobs.js
+++ b/test/schedule-cron-jobs.js
@@ -64,7 +64,7 @@ module.exports = {
     "Runs job every day": function(test) {
       test.expect(3);
 
-      var timeout = 3 * 24 * 60 * 60 * 1000;
+      var timeout = 3 * 24 * 60 * 60 * 1000 + 150;
 
       var job = schedule.scheduleJob('0 0 0 * * *', function() {
         test.ok(true);
@@ -80,7 +80,7 @@ module.exports = {
     "Runs job every week": function(test) {
       test.expect(3);
 
-      var timeout = 3 * 7 * 24 * 60 * 60 * 1000;
+      var timeout = 3 * 7 * 24 * 60 * 60 * 1000 + 150;
 
       var job = schedule.scheduleJob('0 0 0 * * 1', function() {
         test.ok(true);
@@ -96,7 +96,7 @@ module.exports = {
     "Runs job every month": function(test) {
       test.expect(48);
 
-      var timeout = 4 * 365.25 * 24 * 60 * 60 * 1000;
+      var timeout = 4 * 365.25 * 24 * 60 * 60 * 1000 + 150;
 
       var job = schedule.scheduleJob('0 0 0 1 * *', function() {
         test.ok(true);
@@ -113,7 +113,7 @@ module.exports = {
     "Runs job every year": function(test) {
       test.expect(4);
 
-      var timeout = 4 * 365.25 * 24 * 60 * 60 * 1000;
+      var timeout = 4 * 365.25 * 24 * 60 * 60 * 1000 + 150;
 
       var job = schedule.scheduleJob('0 0 0 1 1 *', function() {
         test.ok(true);

--- a/test/schedule-cron-jobs.js
+++ b/test/schedule-cron-jobs.js
@@ -10,9 +10,7 @@ var clock;
 module.exports = {
   ".scheduleJob(cron_expr, fn)": {
     setUp: function(cb) {
-      var now = Date.now();
       clock = sinon.useFakeTimers();
-      clock.tick(now);
       cb();
     },
     "Runs job every second": function(test) {
@@ -34,7 +32,7 @@ module.exports = {
     "Runs job every minute": function(test) {
       test.expect(3);
 
-      var timeout = 3 * 60 * 1000;
+      var timeout = 3 * 60 * 1000 + 150;
 
       var job = schedule.scheduleJob('0 * * * * *', function() {
         test.ok(true);
@@ -50,7 +48,7 @@ module.exports = {
     "Runs job every hour": function(test) {
       test.expect(3);
 
-      var timeout = 3 * 60 * 60 * 1000;
+      var timeout = 3 * 60 * 60 * 1000 + 150;
 
       var job = schedule.scheduleJob('0 0 * * * *', function() {
         test.ok(true);


### PR DESCRIPTION
This `cron-parser` version adds support for timezone in `CronDate` and
fixes multiple bugs.
This commit does not add support for timezones in `node-schedule`, it
just bumps the dependency while keeping the same functionality.