### PR TITLE
Removing infinite loop with invalid rules

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -336,9 +336,64 @@ function RecurrenceRule(year, month, date, dayOfWeek, hour, minute, second) {
   this.second = (second == null) ? 0 : second;
 }
 
+RecurrenceRule.prototype.isValid = function() {
+  function isValidType(num) {
+    if (Array.isArray(num) || (num instanceof Array)) {
+      return num.every(function(e) {
+        return isValidType(e);
+      });
+    }
+    return !(Number.isNaN(Number(num)) && !(num instanceof Range));
+  }
+  if (this.month !== null && (this.month < 0 || this.month > 11 || !isValidType(this.month))) {
+    return false;
+  }
+  if (this.dayOfWeek !== null && (this.dayOfWeek < 0 || this.dayOfWeek > 6 || !isValidType(this.dayOfWeek))) {
+    return false;
+  }
+  if (this.hour !== null && (this.hour < 0 || this.hour > 23 || !isValidType(this.hour))) {
+    return false;
+  }
+  if (this.minute !== null && (this.minute < 0 || this.minute > 59 || !isValidType(this.minute))) {
+    return false;
+  }
+  if (this.second !== null && (this.second < 0 || this.second > 59 || !isValidType(this.second))) {
+    return false;
+  }
+  if (this.date !== null) {
+    if(!isValidType(this.date)) {
+      return false;
+    }
+    switch (this.month) {
+      case 3:
+      case 5:
+      case 8:
+      case 10:
+        if (this.date < 1 || this. date > 30) {
+          return false;
+        }
+        break;
+      case 1:
+        if (this.date < 1 || this. date > 29) {
+          return false;
+        }
+        break;
+      default:
+        if (this.date < 1 || this. date > 31) {
+          return false;
+        }
+    }
+  }
+  return true;
+};
+
 RecurrenceRule.prototype.nextInvocationDate = function(base) {
   base = (base instanceof Date) ? base : (new Date());
   if (!this.recurs) {
+    return null;
+  }
+
+  if(!this.isValid()) {
     return null;
   }
 
@@ -398,7 +453,6 @@ RecurrenceRule.prototype.nextInvocationDate = function(base) {
 
     break;
   }
-
   return next;
 };
 

--- a/test/recurrence-rule-test.js
+++ b/test/recurrence-rule-test.js
@@ -295,10 +295,80 @@ module.exports = {
       rule.second = '50';
       rule.minute = '5';
       rule.hour = '10';
-
       var next = rule.nextInvocationDate(base);
-
       test.deepEqual(new Date(2010, 3, 30, 10, 5, 50, 0), next);
+      test.done();
+    },
+    "nextInvocationDate on an invalid month should return null": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.month = 12;
+      var next = rule.nextInvocationDate(next);
+      test.equal(next, null);
+
+      var rule = new schedule.RecurrenceRule();
+      rule.month = 'asdfasdf';
+      next = rule.nextInvocationDate(next);
+      test.equal(next, null);
+
+      test.done();
+    },
+    "nextInvocationDate on an invalid second should return null": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.second = 60;
+      var next = rule.nextInvocationDate(next);
+      test.equal(next, null);
+
+      var rule = new schedule.RecurrenceRule();
+      rule.second = 'asdfasdf';
+      next = rule.nextInvocationDate(next);
+      test.equal(next, null);
+
+      test.done();
+    },
+    "nextInvocationDate on an invalid hour should return null": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.hour = 24;
+      var next = rule.nextInvocationDate(next);
+      test.equal(next, null);
+
+      var rule = new schedule.RecurrenceRule();
+      rule.hour = 'asdfasdf';
+      next = rule.nextInvocationDate(next);
+      test.equal(next, null);
+
+      test.done();
+    },
+    "nextInvocationDate on an invalid date should return null": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.date = 90;
+      var next = rule.nextInvocationDate(next);
+      test.equal(next, null);
+
+      // Test February
+      var rule = new schedule.RecurrenceRule();
+      rule.month = 1;
+      rule.date = 30;
+      next = rule.nextInvocationDate(next);
+      test.equal(next, null);
+
+      var rule = new schedule.RecurrenceRule();
+      rule.date = 'asdfasdf';
+      next = rule.nextInvocationDate(next);
+      test.equal(next, null);
+
+      test.done();
+    },
+    "nextInvocationDate on an invalid dayOfWeek should return null": function(test) {
+      var rule = new schedule.RecurrenceRule();
+      rule.dayOfWeek = 90;
+      var next = rule.nextInvocationDate(next);
+      test.equal(next, null);
+
+      var rule = new schedule.RecurrenceRule();
+      rule.dayOfWeek = 'asdfasdf';
+      next = rule.nextInvocationDate(next);
+      test.equal(next, null);
+
       test.done();
     }
   }


### PR DESCRIPTION
Checks the validity of the rule before trying RecurrenceRule.nextInvocationDate, which fixes the infinite looping reported in #317 .  Possibly might be what #108 was referring to as well?

If you want to handle invalid rules differently, perhaps by returning null instead of throwing an error, I can make changes.