### PR TITLE
Fixing lint warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "env": {
-    "node": true
+    "node": true,
+    "es6": true
   },
   "rules": {
     "eqeqeq": ["error", "smart"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,14 +3,14 @@
     "node": true
   },
   "rules": {
-    "eqeqeq": [2, "smart"],
-    "indent": [2, 2],
-    "no-constant-condition": false,
-    "no-redeclare": 1,
-    "no-underscore-dangle": false,
-    "no-use-before-define": [true,"nofunc"],
-    "quotes": [2, "single"],
-    "space-before-blocks": 2,
-    "strict": 2
+    "eqeqeq": ["error", "smart"],
+    "indent": ["error", 2, { "SwitchCase": 1 }],
+    "no-constant-condition": "off",
+    "no-redeclare": "warn",
+    "no-underscore-dangle": "off",
+    "no-use-before-define": ["warn","nofunc"],
+    "quotes": ["error", "single"],
+    "space-before-blocks": "error",
+    "strict": "error"
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,11 @@ node_js:
   - "4"
   - "6"
   - "7"
-before_script: npm run lint
+before_script: >
+  if nvm ls-remote --lts | grep "$(nvm current)"; then
+    echo "running on a LTS node version, linting"
+    eslint .
+  else
+    echo "running on a non-LTS node version, skipping linting"
+  fi
 script: ./node_modules/.bin/istanbul cover ./node_modules/.bin/nodeunit test && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls && rm -rf ./coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ node_js:
 before_script: >
   if nvm ls-remote --lts | grep "$(nvm current)"; then
     echo "running on a LTS node version, linting"
-    eslint .
+    npm test
   else
     echo "running on a non-LTS node version, skipping linting"
   fi

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -15,6 +15,7 @@ var events = require('events'),
 
 /* Job object */
 var anonJobCounter = 0;
+var scheduledJobs = {};
 
 function isValidDate(date) {
   // Taken from http://stackoverflow.com/a/12372720/1562178
@@ -589,8 +590,6 @@ function scheduleNextRecurrence(rule, job, prevDate, endDate) {
 }
 
 /* Convenience methods */
-var scheduledJobs = {};
-
 function scheduleJob() {
   if (arguments.length < 2) {
     return null;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.2",
-    "eslint": "^0.15.1",
+    "eslint": "^3.19.0",
     "istanbul": "^0.4.5",
     "nodeunit": "^0.10.2",
     "sinon": "^1.14.1"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "./lib/schedule.js",
   "scripts": {
     "test": "nodeunit",
-    "lint": "eslint lib"
+    "lint": "eslint lib test"
   },
   "author": {
     "name": "Matt Patenaude",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "quotes": ["off"]
+  }
+}

--- a/test/convenience-method-test.js
+++ b/test/convenience-method-test.js
@@ -37,32 +37,32 @@ module.exports = {
       clock.tick(3250);
     },
     "Job doesn't emit initial 'scheduled' event": function(test) {
-        var job = schedule.scheduleJob(new Date(Date.now() + 1000), function() {});
+      var job = schedule.scheduleJob(new Date(Date.now() + 1000), function() {});
 
-        job.on('scheduled', function() {
-          test.ok(false);
-        });
+      job.on('scheduled', function() {
+        test.ok(false);
+      });
 
-        setTimeout(function() {
-          test.done();
-        }, 1250);
+      setTimeout(function() {
+        test.done();
+      }, 1250);
 
-        clock.tick(1250);
-      },
-      "Won't run job if scheduled in the past": function(test) {
-        test.expect(1);
-        var job = schedule.scheduleJob(new Date(Date.now() - 3000), function() {
-          test.ok(false);
-        });
+      clock.tick(1250);
+    },
+    "Won't run job if scheduled in the past": function(test) {
+      test.expect(1);
+      var job = schedule.scheduleJob(new Date(Date.now() - 3000), function() {
+        test.ok(false);
+      });
 
-        test.equal(job, null);
+      test.equal(job, null);
 
-        setTimeout(function() {
-          test.done();
-        }, 1000);
+      setTimeout(function() {
+        test.done();
+      }, 1000);
 
-        clock.tick(1000);
-      }
+      clock.tick(1000);
+    }
   },
   ".scheduleJob(RecurrenceRule, fn)": {
     "Runs job at interval based on recur rule, repeating indefinitely": function(test) {
@@ -83,44 +83,44 @@ module.exports = {
       clock.tick(3250);
     },
     "Job doesn't emit initial 'scheduled' event": function(test) {
-        /*
-         * If this was Job#schedule it'd fire 4 times.
-         */
-        test.expect(3);
+      /*
+        * If this was Job#schedule it'd fire 4 times.
+        */
+      test.expect(3);
 
-        var rule = new schedule.RecurrenceRule();
-        rule.second = null; // fire every second
+      var rule = new schedule.RecurrenceRule();
+      rule.second = null; // fire every second
 
-        var job = new schedule.scheduleJob(rule, function() {});
+      var job = new schedule.scheduleJob(rule, function() {});
 
-        job.on('scheduled', function(runOnDate) {
-          test.ok(true);
-        });
+      job.on('scheduled', function(runOnDate) {
+        test.ok(true);
+      });
 
-        setTimeout(function() {
-          job.cancel();
-          test.done();
-        }, 3250);
+      setTimeout(function() {
+        job.cancel();
+        test.done();
+      }, 3250);
 
-        clock.tick(3250);
-      },
-      "Doesn't invoke job if recur rule schedules it in the past": function(test) {
-        test.expect(1);
-        var rule = new schedule.RecurrenceRule();
-        rule.year = 1960;
+      clock.tick(3250);
+    },
+    "Doesn't invoke job if recur rule schedules it in the past": function(test) {
+      test.expect(1);
+      var rule = new schedule.RecurrenceRule();
+      rule.year = 1960;
 
-        var job = schedule.scheduleJob(rule, function() {
-          test.ok(false);
-        });
-        
-        test.equal(job, null);
+      var job = schedule.scheduleJob(rule, function() {
+        test.ok(false);
+      });
+      
+      test.equal(job, null);
 
-        setTimeout(function() {
-          test.done();
-        }, 1000);
+      setTimeout(function() {
+        test.done();
+      }, 1000);
 
-        clock.tick(1000);
-      }
+      clock.tick(1000);
+    }
   },
   ".scheduleJob({...}, fn)": {
     "Runs job at interval based on object, repeating indefinitely": function(test) {
@@ -140,46 +140,46 @@ module.exports = {
       clock.tick(3250);
     },
     "Job doesn't emit initial 'scheduled' event": function(test) {
-        /*
-         * With Job#schedule this would be 3:
-         *  scheduled at time 0
-         *  scheduled at time 1000
-         *  scheduled at time 2000
-         */
-        test.expect(2);
+      /*
+        * With Job#schedule this would be 3:
+        *  scheduled at time 0
+        *  scheduled at time 1000
+        *  scheduled at time 2000
+        */
+      test.expect(2);
 
-        var job = schedule.scheduleJob({
-          second: null // fire every second
-        }, function() {});
+      var job = schedule.scheduleJob({
+        second: null // fire every second
+      }, function() {});
 
-        job.on('scheduled', function() {
-          test.ok(true);
-        });
+      job.on('scheduled', function() {
+        test.ok(true);
+      });
 
-        setTimeout(function() {
-          job.cancel();
-          test.done();
-        }, 2250);
+      setTimeout(function() {
+        job.cancel();
+        test.done();
+      }, 2250);
 
-        clock.tick(2250);
-      },
-      "Doesn't invoke job if object schedules it in the past": function(test) {
-        test.expect(1);
+      clock.tick(2250);
+    },
+    "Doesn't invoke job if object schedules it in the past": function(test) {
+      test.expect(1);
+    
+      var job = schedule.scheduleJob({
+        year: 1960
+      }, function() {
+        test.ok(false);
+      });
       
-        var job = schedule.scheduleJob({
-          year: 1960
-        }, function() {
-          test.ok(false);
-        });
-        
-        test.equal(job, null);
+      test.equal(job, null);
 
-        setTimeout(function() {
-          test.done();
-        }, 1000);
+      setTimeout(function() {
+        test.done();
+      }, 1000);
 
-        clock.tick(1000);
-      }
+      clock.tick(1000);
+    }
   },
   ".scheduleJob({...}, {...}, fn)": {
     "Callback called for each job if callback is provided": function(test) {

--- a/test/date-convenience-methods-test.js
+++ b/test/date-convenience-methods-test.js
@@ -38,7 +38,7 @@ module.exports = {
     }
   },
   "UTC": {
-     "Should accept a valid UTC date in milliseconds": function(test) {
+    "Should accept a valid UTC date in milliseconds": function(test) {
       test.expect(1);
 
       schedule.scheduleJob(new Date(Date.now() + 1000).getTime(), function() {

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -199,47 +199,47 @@ module.exports = {
       clock.tick(3250);
     },
     "Job emits 'scheduled' event for every next invocation": function(test) {
-        // Job will run 3 times but be scheduled 4 times, 4th run never happens
-        // due to cancel.
-        test.expect(4);
+      // Job will run 3 times but be scheduled 4 times, 4th run never happens
+      // due to cancel.
+      test.expect(4);
 
-        var job = new schedule.Job(function() {});
+      var job = new schedule.Job(function() {});
 
-        job.on('scheduled', function(runOnDate) {
-          test.ok(true);
-        });
+      job.on('scheduled', function(runOnDate) {
+        test.ok(true);
+      });
 
-        var rule = new schedule.RecurrenceRule();
-        rule.second = null; // fire every second
+      var rule = new schedule.RecurrenceRule();
+      rule.second = null; // fire every second
 
-        job.schedule(rule);
+      job.schedule(rule);
 
-        setTimeout(function() {
-          job.cancel();
-          test.done();
-        }, 3250);
+      setTimeout(function() {
+        job.cancel();
+        test.done();
+      }, 3250);
 
-        clock.tick(3250);
-      },
-      "Doesn't invoke job if recur rule schedules it in the past": function(test) {
-        test.expect(0);
+      clock.tick(3250);
+    },
+    "Doesn't invoke job if recur rule schedules it in the past": function(test) {
+      test.expect(0);
 
-        var job = new schedule.Job(function() {
-          test.ok(false);
-        });
+      var job = new schedule.Job(function() {
+        test.ok(false);
+      });
 
-        var rule = new schedule.RecurrenceRule();
-        rule.year = 2000;
+      var rule = new schedule.RecurrenceRule();
+      rule.year = 2000;
 
-        job.schedule(rule);
+      job.schedule(rule);
 
-        setTimeout(function() {
-          job.cancel();
-          test.done();
-        }, 1000);
+      setTimeout(function() {
+        job.cancel();
+        test.done();
+      }, 1000);
 
-        clock.tick(1000);
-      }
+      clock.tick(1000);
+    }
   },
   "#schedule({...})": {
     "Runs job at interval based on object, repeating indefinitely": function(test) {
@@ -261,45 +261,45 @@ module.exports = {
       clock.tick(3250);
     },
     "Job emits 'scheduled' event for every next invocation": function(test) {
-        // Job will run 3 times but be scheduled 4 times, 4th run never happens
-        // due to cancel.
-        test.expect(4);
+      // Job will run 3 times but be scheduled 4 times, 4th run never happens
+      // due to cancel.
+      test.expect(4);
 
-        var job = new schedule.Job(function() {});
+      var job = new schedule.Job(function() {});
 
-        job.on('scheduled', function(runOnDate) {
-          test.ok(true);
-        });
+      job.on('scheduled', function(runOnDate) {
+        test.ok(true);
+      });
 
-        job.schedule({
-          second: null // Fire every second
-        });
+      job.schedule({
+        second: null // Fire every second
+      });
 
-        setTimeout(function() {
-          job.cancel();
-          test.done();
-        }, 3250);
+      setTimeout(function() {
+        job.cancel();
+        test.done();
+      }, 3250);
 
-        clock.tick(3250);
-      },
-      "Doesn't invoke job if object schedules it in the past": function(test) {
-        test.expect(0);
+      clock.tick(3250);
+    },
+    "Doesn't invoke job if object schedules it in the past": function(test) {
+      test.expect(0);
 
-        var job = new schedule.Job(function() {
-          test.ok(false);
-        });
+      var job = new schedule.Job(function() {
+        test.ok(false);
+      });
 
-        job.schedule({
-          year: 2000
-        });
+      job.schedule({
+        year: 2000
+      });
 
-        setTimeout(function() {
-          job.cancel();
-          test.done();
-        }, 1000);
+      setTimeout(function() {
+        job.cancel();
+        test.done();
+      }, 1000);
 
-        clock.tick(1000);
-      }
+      clock.tick(1000);
+    }
   },
   "#schedule('jobName', {...})": {
     "Runs job with a custom name input": function(test) {

--- a/test/recurrence-rule-test.js
+++ b/test/recurrence-rule-test.js
@@ -302,72 +302,72 @@ module.exports = {
     "nextInvocationDate on an invalid month should return null": function(test) {
       var rule = new schedule.RecurrenceRule();
       rule.month = 12;
-      var next = rule.nextInvocationDate(next);
+      var next = rule.nextInvocationDate();
       test.equal(next, null);
 
-      var rule = new schedule.RecurrenceRule();
-      rule.month = 'asdfasdf';
-      next = rule.nextInvocationDate(next);
-      test.equal(next, null);
+      var rule2 = new schedule.RecurrenceRule();
+      rule2.month = 'asdfasdf';
+      var next2 = rule2.nextInvocationDate(next);
+      test.equal(next2, null);
 
       test.done();
     },
     "nextInvocationDate on an invalid second should return null": function(test) {
       var rule = new schedule.RecurrenceRule();
       rule.second = 60;
-      var next = rule.nextInvocationDate(next);
+      var next = rule.nextInvocationDate();
       test.equal(next, null);
 
-      var rule = new schedule.RecurrenceRule();
-      rule.second = 'asdfasdf';
-      next = rule.nextInvocationDate(next);
-      test.equal(next, null);
+      var rule2 = new schedule.RecurrenceRule();
+      rule2.second = 'asdfasdf';
+      var next2 = rule2.nextInvocationDate();
+      test.equal(next2, null);
 
       test.done();
     },
     "nextInvocationDate on an invalid hour should return null": function(test) {
       var rule = new schedule.RecurrenceRule();
       rule.hour = 24;
-      var next = rule.nextInvocationDate(next);
+      var next = rule.nextInvocationDate();
       test.equal(next, null);
 
-      var rule = new schedule.RecurrenceRule();
-      rule.hour = 'asdfasdf';
-      next = rule.nextInvocationDate(next);
-      test.equal(next, null);
+      var rule2 = new schedule.RecurrenceRule();
+      rule2.hour = 'asdfasdf';
+      var next2 = rule2.nextInvocationDate();
+      test.equal(next2, null);
 
       test.done();
     },
     "nextInvocationDate on an invalid date should return null": function(test) {
       var rule = new schedule.RecurrenceRule();
       rule.date = 90;
-      var next = rule.nextInvocationDate(next);
+      var next = rule.nextInvocationDate();
       test.equal(next, null);
 
       // Test February
-      var rule = new schedule.RecurrenceRule();
-      rule.month = 1;
-      rule.date = 30;
-      next = rule.nextInvocationDate(next);
-      test.equal(next, null);
+      var rule2 = new schedule.RecurrenceRule();
+      rule2.month = 1;
+      rule2.date = 30;
+      var next2 = rule2.nextInvocationDate();
+      test.equal(next2, null);
 
-      var rule = new schedule.RecurrenceRule();
-      rule.date = 'asdfasdf';
-      next = rule.nextInvocationDate(next);
-      test.equal(next, null);
+      var rule3 = new schedule.RecurrenceRule();
+      rule3.date = 'asdfasdf';
+      var next3 = rule3.nextInvocationDate();
+      test.equal(next3, null);
 
       test.done();
     },
     "nextInvocationDate on an invalid dayOfWeek should return null": function(test) {
       var rule = new schedule.RecurrenceRule();
       rule.dayOfWeek = 90;
-      var next = rule.nextInvocationDate(next);
+      var next = rule.nextInvocationDate();
       test.equal(next, null);
 
-      var rule = new schedule.RecurrenceRule();
-      rule.dayOfWeek = 'asdfasdf';
-      next = rule.nextInvocationDate(next);
-      test.equal(next, null);
+      var rule2 = new schedule.RecurrenceRule();
+      rule2.dayOfWeek = 'asdfasdf';
+      var next2 = rule.nextInvocationDate();
+      test.equal(next2, null);
 
       test.done();
     }


### PR DESCRIPTION
* Updated the eslint version got rid of the two incorrect `[var] is already defined` warnings.
* Moved the scheduledJobs object to earlier in file got rid of the two `no-use-before-define` warnings.
* In eslintrc, converted the rule levels from numbers to text to improve readability.

This results in a clean output from `npm run lint`.