### PR TITLE
src: make sure the job runs on the exact date

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -490,7 +490,7 @@ function recurMatch(val, matcher) {
 
 /* Date-based scheduler */
 function runOnDate(date, job) {
-  var now = (new Date()).getTime();
+  var now = Date.now();
   var then = date.getTime();
 
   if (then < now) {
@@ -498,7 +498,12 @@ function runOnDate(date, job) {
     return null;
   }
 
-  return lt.setTimeout(job, (then - now));
+  return lt.setTimeout(function() {
+    if (then > Date.now())
+      runOnDate(date, job);
+    else
+      job();
+  }, (then - now));
 }
 
 var invocations = [];


### PR DESCRIPTION
It can happen that a recurrent job is scheduled a little before (less
than a second) the expected date. If this happens, the next recurrence
happens in the expected data (less than a second later) so a job is run
twice at the same time. To avoid this, don't run the job when initially
scheduled and reschedule the job to run in the expected date.

Fixes: https://github.com/node-schedule/node-schedule/issues/263