### PR TITLE
README.md: fix cron string diagram consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The cron format consists of:
 ```
 *    *    *    *    *    *
 ┬    ┬    ┬    ┬    ┬    ┬
-│    │    │    │    │    |
+│    │    │    │    │    │
 │    │    │    │    │    └ day of week (0 - 7) (0 or 7 is Sun)
 │    │    │    │    └───── month (1 - 12)
 │    │    │    └────────── day of month (1 - 31)


### PR DESCRIPTION
The vertical line character used in the weekday field is different than
the vertical line characters used for the other fields; it is a pipe
character (EASCII 124) rather than a vertical line (EASCII 179).  All
other line characters in the diagram are from the line-drawing
character set, so I believe the intention was to use such a character
in this case as well.