### PR TITLE
avoid discarding the tz parameter

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -188,10 +188,14 @@ Job.prototype.schedule = function(spec) {
   var end;
   var tz;
 
+  // save passed-in value before 'spec' is replaced
+  if (typeof spec === 'object' && 'tz' in spec) {
+    tz = spec.tz;
+  }
+
   if (typeof spec === 'object' && spec.rule) {
     start = spec.start || undefined;
     end = spec.end || undefined;
-    tz = spec.tz;
     spec = spec.rule;
 
     if (start) {


### PR DESCRIPTION
The 'tz' parameter is currently being discarded unless it is passed along with a cron string. This sets it so that it can be used for any rule type.