### PR TITLE
Fix memory leak when scheduling one-off job

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -232,6 +232,7 @@ Job.prototype.schedule = function(spec) {
 
     if ((spec instanceof Date) && (isValidDate(spec))) {
       spec = new CronDate(spec);
+      self.isOneTimeJob = true;
       if (spec.getTime() >= Date.now()) {
         inv = new Invocation(self, spec);
         scheduleInvocation(inv);
@@ -534,6 +535,9 @@ function prepareNextInvocation() {
     var job = currentInvocation.job;
     var cinv = currentInvocation;
     currentInvocation.timerID = runOnDate(currentInvocation.fireDate, function() {
+      if (job.isOneTimeJob) {
+        job.cancel();
+      }
       currentInvocationFinished();
 
       if (job.callback) {


### PR DESCRIPTION
when call scheduleJob() with a number or date, it will turn to one-off job, but this kind of job will remain in 'scheduledJobs', after scheduling plenty of one-off jobs, memory usage will increase to a crazy number~

![image](https://user-images.githubusercontent.com/14833440/50547899-513ee600-0c7e-11e9-8a10-711e021af45c.png)

simple test codes could reproduce this issue
`
const schedule = require('node-schedule')
const heapdump = require('heapdump')

let counter = 0

// job will be triggered after 5s
let testSchedule = new Date(new Date().valueOf() + 5000)

// simulate 1000 one-off jobs
for(let i = 0; i < 1000; i++) {
  let job = schedule.scheduleJob(testSchedule, function() {
    // one-off job, do nothing
  })
}
setInterval(() => {
  ++counter
  heapdump.writeSnapshot(counter + ".heapsnapshot", () => {})
}, 4000)
`