### PR TITLE
Clarify Month Scheduling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The cron format consists of:
 ┬    ┬    ┬    ┬    ┬    ┬
 │    │    │    │    │    │
 │    │    │    │    │    └ day of week (0 - 7) (0 or 7 is Sun)
-│    │    │    │    └───── month (1 - 12)
+│    │    │    │    └───── month (0 - 11)
 │    │    │    └────────── day of month (1 - 31)
 │    │    └─────────────── hour (0 - 23)
 │    └──────────────────── minute (0 - 59)


### PR DESCRIPTION
The cron scheduling map throw me off a bit by saying node-schedule's months are between 1-12 when they are actually between 0-11. I thought this may have been specific to node-schedule and didn't think anything of it only to later figure out this piece of the documentation is inaccurate and can confuse many others as well as it did me.