### PR TITLE
Add later node versions to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
   - "4"
   - "6"
   - "7"
+  - "node"
+  - "lts/*"
 before_script: >
   if nvm ls-remote --lts | grep "$(nvm current)"; then
     echo "running on a LTS node version, linting"


### PR DESCRIPTION
The latest version being tested by travis is Node.js 7 which is quite old and is not supported anymore. I've added more ["future-proof" tags](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions) which will test the latest versions of Node.js

https://nodejs.org/en/about/releases/

Added:

- "node" - latest stable Node.js release
- "lts/*" -  latest LTS Node.js release