### PR TITLE
Added tz rule to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ var j = schedule.scheduleJob(rule, function(){
 - `month (0-11)`
 - `year`
 - `dayOfWeek (0-6) Starting with Sunday`
+- `tz`
+
+A list of acceptable tz (timezone) values can be found at <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>
 
 > **Note**: It's worth noting that the default value of a component of a recurrence rule is
 > `null` (except for second, which is 0 for familiarity with cron). *If we did not

--- a/README.md
+++ b/README.md
@@ -163,6 +163,20 @@ var j = schedule.scheduleJob(rule, function(){
 });
 ```
 
+Timezones are also supported. Here is an example of executing at the start of every day in the UTC timezone.
+
+```js
+var rule = new schedule.RecurrenceRule();
+rule.hour = 0;
+rule.tz = 'Etc/UTC';
+
+var j = schedule.scheduleJob(rule, function(){
+  console.log('A new day has begun in the UTC timezone!');
+});
+```
+
+A list of acceptable tz (timezone) values can be found at <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>
+
 #### RecurrenceRule properties
 
 - `second (0-59)`
@@ -174,7 +188,6 @@ var j = schedule.scheduleJob(rule, function(){
 - `dayOfWeek (0-6) Starting with Sunday`
 - `tz`
 
-A list of acceptable tz (timezone) values can be found at <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>
 
 > **Note**: It's worth noting that the default value of a component of a recurrence rule is
 > `null` (except for second, which is 0 for familiarity with cron). *If we did not


### PR DESCRIPTION
Saw timezone support has been added to node-schedule finally but the readme doesn't seem to reflect that. Hoping this might make it a bit more clear