### PR TITLE
Remove support for job objects

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,3 +3,17 @@
 ### Upgrading to version 2.0.0+
 
 * Node.js versions older than 6 are no longer supported, please update your environment before upgrading.
+* The `scheduleJob()` method no longer supports passing an object with the job method. If you were using an object, pass the job method directly.  
+
+  E.g. code that previously looked like this:
+  ```javascript
+  const obj = {
+   execute() {}
+  };
+  Scheduler.scheduleJob(obj);
+  ```
+  should be changed to something like this:
+  ```javascript
+  function execute() {}
+  Scheduler.scheduleJob(execute);
+  ```

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -607,7 +607,7 @@ function scheduleNextRecurrence(rule, job, prevDate, endDate) {
 /* Convenience methods */
 function scheduleJob() {
   if (arguments.length < 2) {
-    return null;
+    throw new RangeError('Invalid number of arguments');
   }
 
   const name = (arguments.length >= 3 && typeof arguments[0] === 'string') ? arguments[0] : null;
@@ -616,7 +616,7 @@ function scheduleJob() {
   const callback = name ? arguments[3] : arguments[2];
 
   if (typeof method !== 'function') {
-    return null;
+    throw new RangeError('The job method must be a function.');
   }
 
   const job = new Job(name, method, callback);

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -168,12 +168,8 @@ function Job(name, job, callback) {
 util.inherits(Job, events.EventEmitter);
 
 Job.prototype.invoke = function(fireDate) {
-  if (typeof this.job == 'function') {
-    this.setTriggeredJobs(this.triggeredJobs() + 1);
-    return this.job(fireDate);
-  } else {
-    this.job.execute(fireDate);
-  }
+  this.setTriggeredJobs(this.triggeredJobs() + 1);
+  return this.job(fireDate);
 };
 
 Job.prototype.runOnDate = function(date) {
@@ -618,6 +614,10 @@ function scheduleJob() {
   const spec = name ? arguments[1] : arguments[0];
   const method = name ? arguments[2] : arguments[1];
   const callback = name ? arguments[3] : arguments[2];
+
+  if (typeof method !== 'function') {
+    return null;
+  }
 
   const job = new Job(name, method, callback);
 

--- a/test/convenience-method-test.js
+++ b/test/convenience-method-test.js
@@ -22,8 +22,29 @@ test("Convenience method", function (t) {
 
       job.cancel();
       test.end();
-    })
-  })
+    });
+
+    t.test("Returns null if fewer than 2 arguments are passed", function (test) {
+      test.plan(1);
+
+      const job = schedule.scheduleJob(function() {});
+
+      test.equal(job, null);
+
+      test.end();
+    });
+
+    t.test("Returns null if the method argument is not a function", function (test) {
+      test.plan(1);
+
+      const job = schedule.scheduleJob(new Date(Date.now() + 1000), {});
+
+      test.equal(job, null);
+
+      test.end();
+    });
+  });
+
   t.test(".scheduleJob(Date, fn)", function(t) {
     t.test("Runs job once at some date", function(test) {
       test.plan(1);

--- a/test/convenience-method-test.js
+++ b/test/convenience-method-test.js
@@ -27,9 +27,11 @@ test("Convenience method", function (t) {
     t.test("Returns null if fewer than 2 arguments are passed", function (test) {
       test.plan(1);
 
-      const job = schedule.scheduleJob(function() {});
+      const fn = function() {
+        return schedule.scheduleJob(function() {});
+      };
 
-      test.equal(job, null);
+      test.throws(fn, RangeError);
 
       test.end();
     });
@@ -37,9 +39,11 @@ test("Convenience method", function (t) {
     t.test("Returns null if the method argument is not a function", function (test) {
       test.plan(1);
 
-      const job = schedule.scheduleJob(new Date(Date.now() + 1000), {});
+      const fn = function() {
+        return schedule.scheduleJob(new Date(Date.now() + 1000), {});
+      };
 
-      test.equal(job, null);
+      test.throws(fn, RangeError);
 
       test.end();
     });


### PR DESCRIPTION
This removes support for passing job objects with an `execute()` method instead of a function.

This reverts e7c475f (#57).

Fixes #183 (see #220).

This is technically a breaking change, although this "feature" was never documented.