### PR TITLE
Emit `error` events

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,19 @@ Every scheduled job in Node Schedule is represented by a `Job` object. You can
 create jobs manually, then execute the `schedule()` method to apply a schedule,
 or use the convenience function `scheduleJob()` as demonstrated below.
 
-`Job` objects are `EventEmitter`'s, and emit a `run` event after each execution.
-They also emit a `scheduled` event each time they're scheduled to run, and a
-`canceled` event when an invocation is canceled before it's executed (both events
-receive a JavaScript date object as a parameter). Note that jobs are scheduled the
-first time immediately, so if you create a job using the `scheduleJob()`
-convenience method, you'll miss the first `scheduled` event, but you can query the
-invocation manually (see below). Also note that `canceled` is the single-L American
-spelling.
+`Job` objects are `EventEmitter`s, and emit the following events:
+* A `run` event after each execution.
+* A `scheduled` event each time they're scheduled to run.
+* A `canceled` event when an invocation is canceled before it's executed.  
+  Note that `canceled` is the single-L American spelling.
+* An `error` event when a job invocation triggered by a schedule throws or returns
+  a rejected `Promise`.
+
+(Both the `scheduled` and `canceled` events receive a JavaScript date object as
+a parameter).  
+Note that jobs are scheduled the first time immediately, so if you create a job
+using the `scheduleJob()` convenience method, you'll miss the first `scheduled`
+event, but you can query the invocation manually (see below).
 
 ### Cron-style Scheduling
 

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -170,7 +170,7 @@ util.inherits(Job, events.EventEmitter);
 Job.prototype.invoke = function(fireDate) {
   if (typeof this.job == 'function') {
     this.setTriggeredJobs(this.triggeredJobs() + 1);
-    this.job(fireDate);
+    return this.job(fireDate);
   } else {
     this.job.execute(fireDate);
   }
@@ -549,8 +549,18 @@ function prepareNextInvocation() {
 
       job.stopTrackingInvocation(cinv);
 
-      job.invoke(cinv.fireDate instanceof CronDate ? cinv.fireDate.toDate() : cinv.fireDate);
-      job.emit('run');
+      try {
+        var result = job.invoke(cinv.fireDate instanceof CronDate ? cinv.fireDate.toDate() : cinv.fireDate);
+        job.emit('run');
+
+        if (Promise && result instanceof Promise) {
+          result.catch(function (err) {
+            job.emit('error', err);
+          });
+        }
+      } catch (err) {
+        job.emit('error', err);
+      }
     });
   }
 }

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -546,7 +546,53 @@ module.exports = {
       }, 2250);
 
       clock.tick(2250);
+    },
+    "Job emits 'error' event when the job synchronously throws an error": function(test) {
+      test.expect(1);
+
+      var error = new Error('test');
+
+      var job = new schedule.Job(function() { throw error; });
+
+      job.on('error', function(err) {
+        test.strictEqual(err, error);
+        test.done()
+      });
+
+      job.schedule(new Date(Date.now() + 3000));
+
+      clock.tick(3250);
+    },
+    "Job emits 'error' event when the job returns a rejected Promise": function(test) {
+      test.expect(1);
+
+      var error = new Error('test');
+
+      var job = new schedule.Job(function() { return Promise.reject(error); });
+
+      job.on('error', function(err) {
+        test.strictEqual(err, error);
+        test.done()
+      });
+
+      job.schedule(new Date(Date.now() + 3000));
+
+      clock.tick(3250);
     }
+  },
+  "When invoked manually": {
+    "It returns the result of the job": function(test) {
+      test.expect(1);
+
+      var job = new schedule.Job(function() {
+        return 1;
+      });
+
+      var result = job.invoke();
+
+      test.strictEqual(result, 1);
+      test.done();
+    },
   },
   tearDown: function(cb) {
     clock.restore();


### PR DESCRIPTION
Previously, if a job was invoked and caused an error, it would cause an unhandled exception or an unhandled promise rejection. The only way for a user to handle it was to wrap the actual job in a wrapper function.

This makes it easier to handle by catching the error and emitting an `error` event when an error is thrown or a rejected Promise is a returned.
As a bonus, the result of the job is returned when `job.invoke()` is called.

Fixes #389.