### PR TITLE
Add missing minute to timezone RecurrenceRule example

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Timezones are also supported. Here is an example of executing at the start of ev
 ```js
 const rule = new schedule.RecurrenceRule();
 rule.hour = 0;
+rule.minute = 0;
 rule.tz = 'Etc/UTC';
 
 const job = schedule.scheduleJob(rule, function(){


### PR DESCRIPTION
The documentation for [Recurrence Rule Scheduling](https://github.com/node-schedule/node-schedule#recurrence-rule-scheduling) implies that the code will be run every day at exactly midnight, once.

```javascript
const rule = new schedule.RecurrenceRule();
rule.hour = 0;
rule.tz = 'Etc/UTC';

const job = schedule.scheduleJob(rule, function(){
  console.log('A new day has begun in the UTC timezone!');
});
```

It later says in a quote
> If we did not explicitly set minute to 0 above, the message would have instead been logged at 5:00pm, 5:01pm, 5:02pm, ..., 5:59pm. Probably not what you want.

I made the mistake of not reading this, and I think many others (#498) could also make the same mistake. Depending on the computation within the schedule function, this could be costly!

This PR updates the README to include the minute setting. It sounds like this was the original intention.

Thanks!