### PR TITLE
Emit a success event after a successful job invocation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ or use the convenience function `scheduleJob()` as demonstrated below.
   Note that `canceled` is the single-L American spelling.
 * An `error` event when a job invocation triggered by a schedule throws or returns
   a rejected `Promise`.
+* A `success` event when a job invocation triggered by a schedule returns successfully or
+  returns a resolved `Promise`. In any case, the `success` event receives the value returned
+  by the callback or in case of a promise, the resolved value.
 
 (Both the `scheduled` and `canceled` events receive a JavaScript date object as
 a parameter).  

--- a/lib/Invocation.js
+++ b/lib/Invocation.js
@@ -269,9 +269,14 @@ function prepareNextInvocation() {
         job.emit('run');
 
         if (result instanceof Promise) {
-          result.catch(function (err) {
-            job.emit('error', err);
-          });
+          result.then(function(value) {
+            job.emit('success', value);
+          })
+            .catch(function (err) {
+              job.emit('error', err);
+            });
+        } else {
+          job.emit('success', result);
         }
       } catch (err) {
         job.emit('error', err);

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -573,6 +573,10 @@ test("Job", function (t) {
         throw error;
       });
 
+      // make sure no success event has been emitted
+      job.on('success', function () {
+        test.end(new Error("success emitted on failed invocation"))
+      })
       job.on('error', function (err) {
         test.strictEqual(err, error);
         test.end()
@@ -592,8 +596,50 @@ test("Job", function (t) {
         return Promise.reject(error);
       });
 
+      // make sure no success event has been emitted
+      job.on('success', function () {
+        test.end(new Error("success emitted on failed invocation"))
+      })
       job.on('error', function (err) {
         test.strictEqual(err, error);
+        test.end()
+      });
+
+      job.schedule(new Date(Date.now() + 3000));
+
+      clock.tick(3250);
+    })
+
+    t.test("Job emits 'success' event when the job synchronously returns successfully", function (test) {
+      test.plan(1);
+
+      const returnValue = { test: "data" }
+
+      const job = new schedule.Job(function () {
+        return returnValue
+      });
+
+      job.on('success', function (value) {
+        test.strictEqual(value, returnValue)
+        test.end()
+      });
+
+      job.schedule(new Date(Date.now() + 3000));
+
+      clock.tick(3250);
+    })
+
+    t.test("Job emits 'success' event when the job returns a resolved Promise", function (test) {
+      test.plan(1);
+
+      const returnValue = { test: "data" }
+
+      const job = new schedule.Job(function () {
+        return Promise.resolve(returnValue);
+      });
+
+      job.on('success', function (value) {
+        test.strictEqual(value, returnValue);
         test.end()
       });
 


### PR DESCRIPTION
Dear Developers & Maintainers, first of all thanks a lot for this package, it proved itself very useful in my daily projects! I stumbled upon a use case which I could not cover using the currently available API. I therefore would like to propose a new feature consisting of an additional `success` event.

## Problem Description
I came across a situation where we need to track the number of consecutive failed invocations. Therefore, it would be helpful to not only be aware of failed job invocations, but also successful ones. This allows us to reset the internal counter of consecutive failures. 

## Proposed solution
When the callback of a job invocation returns successfully (i.e. returning without raising an error), a `success` event is emitted receiving the data returned by the callback. In case of the callback returning a promise, the `success` event is emitted if and only if the promise resolves successfully, receiving the resolved value.

What do you think of this proposal? Thanks for looking into it.

Cheers,
remolueoend