### PR TITLE
Added jitter option

### DIFF
--- a/lib/Invocation.js
+++ b/lib/Invocation.js
@@ -217,9 +217,9 @@ function recurMatch(val, matcher) {
 }
 
 /* Date-based scheduler */
-function runOnDate(date, job) {
+function runOnDate(date, jitterMS, job) {
   const now = Date.now();
-  const then = date.getTime();
+  const then = date.getTime() + jitterMS;
 
   return lt.setTimeout(function() {
     if (then > Date.now())
@@ -236,6 +236,13 @@ function scheduleInvocation(invocation) {
   invocation.job.emit('scheduled', date);
 }
 
+function calculateJitterMs(jitter) {
+  if (!jitter) {
+    return 0;
+  }
+  return Math.floor(Math.random() * jitter) * 1000;
+}
+
 function prepareNextInvocation() {
   if (invocations.length > 0 && currentInvocation !== invocations[0]) {
     if (currentInvocation !== null) {
@@ -248,7 +255,8 @@ function prepareNextInvocation() {
 
     const job = currentInvocation.job;
     const cinv = currentInvocation;
-    currentInvocation.timerID = runOnDate(currentInvocation.fireDate, function() {
+    const jitterMS = calculateJitterMs(currentInvocation.job.jitter);
+    currentInvocation.timerID = runOnDate(currentInvocation.fireDate, jitterMS, function() {
       currentInvocationFinished();
 
       if (job.callback) {

--- a/lib/Job.js
+++ b/lib/Job.js
@@ -21,7 +21,7 @@ function resolveAnonJobName() {
   return `<Anonymous Job ${anonJobCounter} ${now.toISOString()}>`
 }
 
-function Job(name, job, callback) {
+function Job(name, job, callback, jitter) {
   // setup a private pendingInvocations variable
   this.pendingInvocations = [];
 
@@ -31,6 +31,7 @@ function Job(name, job, callback) {
   // Set scope vars
   const jobName = name && typeof name === 'string' ? name : resolveAnonJobName();
   this.job = name && typeof name === 'function' ? name : job;
+  this.jitter = typeof jitter === 'number' ? Math.min(jitter, 60) : 0;
 
   // Make sure callback is actually a callback
   if (this.job === name) {

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -29,12 +29,13 @@ function scheduleJob() {
   const spec = name ? arguments[1] : arguments[0];
   const method = name ? arguments[2] : arguments[1];
   const callback = name ? arguments[3] : arguments[2];
+  const jitter = name ? arguments[4] : arguments[3];
 
   if (typeof method !== 'function') {
     throw new RangeError('The job method must be a function.');
   }
 
-  const job = new Job(name, method, callback);
+  const job = new Job(name, method, callback, jitter);
 
   if (job.schedule(spec)) {
     return job;


### PR DESCRIPTION
Added a jitter option similar to the in BSD cron to allow
variations in the execution of scheduled jobs.

This is used as an extra option that specifies the number of
seconds jitter to apply.

From the FreeBSD man pages:

>      -j   jitter
>
>      Enable time jitter.  Prior to executing commands, cron will sleep
>      a random number of seconds in the range from 0 to jitter. This
>      will not affect superuser jobs (see -J).  A value for jitter must
>      be between 0 and 60 inclusive.  Default is 0, which effectively
>      disables time jitter.
>
>      This option can help to smooth down system load spikes during mo-
>      ments when a lot of jobs are likely to start at once, e.g., at
>      the beginning of the first minute of each hour.


Example usage:

```javascript
'use strict'
const schedule = require('./lib/schedule');
console.log('Starting a test...');
schedule.scheduleJob(
  'job name',
  '0/10 * * * * *',
  function() {
    const now = new Date();
    console.log(now.toISOString() + ', Firing every 10th second with jitter, ' + now.getTime());
  },
  undefined,
  5);


const rule = new schedule.RecurrenceRule();
rule.second = 42;

schedule.scheduleJob(rule, function() {
  console.log('The answer to life, the universe, and everything!');
});
```

Which produces output like this:

```
% node test.js
2021-12-11T10:36:48.004Z, Firing every 20th second with jitter
2021-12-11T10:36:48.013Z, The (jittery) answer to life, the universe, and everything!
2021-12-11T10:37:09.003Z, Firing every 20th second with jitter
2021-12-11T10:37:25.007Z, Firing every 20th second with jitter
2021-12-11T10:37:43.003Z, Firing every 20th second with jitter
2021-12-11T10:37:43.010Z, The (jittery) answer to life, the universe, and everything!
2021-12-11T10:38:09.003Z, Firing every 20th second with jitter
2021-12-11T10:38:21.003Z, Firing every 20th second with jitter
2021-12-11T10:38:41.007Z, Firing every 20th second with jitter
2021-12-11T10:38:42.008Z, The (jittery) answer to life, the universe, and everything!
2021-12-11T10:39:01.003Z, Firing every 20th second with jitter
2021-12-11T10:39:20.003Z, Firing every 20th second with jitter
2021-12-11T10:39:48.005Z, Firing every 20th second with jitter
2021-12-11T10:39:48.008Z, The (jittery) answer to life, the universe, and everything!
2021-12-11T10:40:05.003Z, Firing every 20th second with jitter
2021-12-11T10:40:21.002Z, Firing every 20th second with jitter
```

All existing unit tests pass, as does lint, but I've not added new unit tests yet - I wanted to check if this would be suitable for the library.

I also need to revisit the parameter handling  as it currently errors if a when using the cron pattern if there is a `jitter` but no `name` argument.

