### PR TITLE
Clear timers in gracefulShutdown()

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -89,13 +89,14 @@ function gracefulShutdown() {
 
   return new Promise(function (resolve) {
     if (running) {
-      setInterval(function () {
+      const timer = setInterval(function () {
         for (let i = 0; i < jobs.length; i++) {
           if (jobs[i].running > 0) {
             return;
           }
         }
 
+        clearInterval(timer);
         resolve();
       }, 500);
     } else {


### PR DESCRIPTION
During graceful shutdown the `setInterval()` was not always cleared. This manifested only if `gracefulShutdown()` was called while a job was running. A consequence is that stopping Node required to call `process.exit(0)`.

If the timer is cleared correctly and no other work is pending in the application, Node exits automatically so the `process.exit(0)` becomes superfluous.

The issue https://github.com/node-schedule/node-schedule/issues/548 can be closed after merging this PR.

I tried adding tests but couldn't figure out how to integrate with existing tests. The idea would have been to call `gracefulShutdown()` then `clock.countTimers()` (https://github.com/sinonjs/fake-timers). But the problems were:

- the current test doesn't make sense to me: `test.plan(1)` vs 2x `test.ok(true)`  https://github.com/node-schedule/node-schedule/blob/017c195e3ababe9a7eb80c2565ef2d9162472e7b/test/graceful-shutdown-test.js
- running the whole testsuite succeeds, but on my machine when only this test is run it hangs (bad isolation?)
- I suspect that a few other tests don't clean their resources correctly and pollute `clock.countTimers()`

Given that this is a simple fix, I suggest it is merged without any new test.