### PR TITLE
Cancel the interval in `gracefulShutdown` when done

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -89,13 +89,13 @@ function gracefulShutdown() {
 
   return new Promise(function (resolve) {
     if (running) {
-      setInterval(function () {
+      const intervalId = setInterval(function () {
         for (let i = 0; i < jobs.length; i++) {
           if (jobs[i].running > 0) {
             return;
           }
         }
-
+        clearInterval(intervalId);
         resolve();
       }, 500);
     } else {


### PR DESCRIPTION
## Change

Cancel the interval in `gracefulShutdown` when done

## Why

When I started using `gracefulShutdown` I noticed the interval remaining active after all in-flight jobs had completed. While fairly harmless, this causes the event loop to keep running, preventing my application from actually shutting down fully 😅 