### PR TITLE
Support Cron-like '*' in object-based job schedules

### DIFF
--- a/lib/Job.js
+++ b/lib/Job.js
@@ -5,7 +5,7 @@ const cronParser = require('cron-parser')
 const CronDate = require('cron-parser/lib/date')
 const sorted = require('sorted-array-functions')
 
-const { scheduleNextRecurrence, scheduleInvocation, cancelInvocation, RecurrenceRule, sorter, Invocation } = require('./Invocation')
+const { scheduleNextRecurrence, scheduleInvocation, cancelInvocation, Range, RecurrenceRule, sorter, Invocation } = require('./Invocation')
 const { isValidDate } = require('./utils/dateUtils')
 
 const scheduledJobs = {};
@@ -237,26 +237,26 @@ Job.prototype.schedule = function(spec) {
       self.isOneTimeJob = false;
       if (!(spec instanceof RecurrenceRule)) {
         const r = new RecurrenceRule();
-        if ('year' in spec) {
+        if ('year' in spec && spec.year !== '*') {
           r.year = spec.year;
         }
         if ('month' in spec) {
-          r.month = spec.month;
+          r.month = spec.month === '*' ? new Range(0, 11, 1) : spec.month;
         }
         if ('date' in spec) {
           r.date = spec.date;
         }
         if ('dayOfWeek' in spec) {
-          r.dayOfWeek = spec.dayOfWeek;
+          r.dayOfWeek = spec.dayOfWeek === '*' ? new Range(0, 6, 1) : spec.dayOfWeek;
         }
         if ('hour' in spec) {
-          r.hour = spec.hour;
+          r.hour = spec.hour === '*' ? new Range(0, 23, 1) : spec.hour;
         }
         if ('minute' in spec) {
-          r.minute = spec.minute;
+          r.minute = spec.minute === '*' ? new Range(0, 59, 1) : spec.minute;
         }
         if ('second' in spec) {
-          r.second = spec.second;
+          r.second = spec.second === '*' ? new Range(0, 59, 1) : spec.second;
         }
 
         spec = r;

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -282,6 +282,30 @@ test("Job", function (t) {
       clock.tick(3250);
     })
 
+    t.test("Runs job at interval based on object, user Cron-like '*'", function (test) {
+      test.plan(3);
+
+      const job = new schedule.Job(function () {
+        test.ok(true);
+      });
+
+      job.schedule({
+        year: '*', // fire every year
+        dayOfWeek: '*', // fire every day of the week
+        month: '*', // fire every month
+        hour: '*', // fire every hour
+        minute: '*', // fire every minute
+        second: '*' // fire every second
+      });
+
+      setTimeout(function () {
+        job.cancel();
+        test.end();
+      }, 3250);
+
+      clock.tick(3250);
+    })
+
     t.test("Doesn't invoke job if object schedules it in the past", function (test) {
       test.plan(0);
 


### PR DESCRIPTION
Updated Job scheduling to interpret '*' in object-based specs as full-range intervals using `Range`.

```javascript
job.schedule({
  year: '*', // fire every year
  dayOfWeek: '*', // fire every day of the week
  month: '*', // fire every month
  hour: '*', // fire every hour
  minute: '*', // fire every minute
  second: '*' // fire every second
});
```